### PR TITLE
enh: restrict events listened to by iframes

### DIFF
--- a/src/js/doc-verification.js
+++ b/src/js/doc-verification.js
@@ -38,17 +38,19 @@ var documentVerification = function documentVerification() {
 	}
 
 	window.addEventListener('message', async event => {
-		config = JSON.parse(event.data);
-		activeScreen = SelectIDType;
+		if (event.data.includes('SmileIdentity::HostedWebIntegration')) {
+			config = JSON.parse(event.data);
+			activeScreen = SelectIDType;
 
-		try {
-			productConstraints = await getProductConstraints();
-			initializeSession(productConstraints);
-			getPartnerParams();
+			try {
+				productConstraints = await getProductConstraints();
+				initializeSession(productConstraints);
+				getPartnerParams();
 
-			localStorage.setItem('SmileIdentityConfig', event.data);
-		} catch (e) {
-			throw e;
+				localStorage.setItem('SmileIdentityConfig', event.data);
+			} catch (e) {
+				throw e;
+			}
 		}
 	}, false);
 

--- a/src/js/ekyc-smartselfie.js
+++ b/src/js/ekyc-smartselfie.js
@@ -40,17 +40,19 @@ var eKYCSmartSelfie = function eKYCSmartSelfie() {
 	}
 
 	window.addEventListener('message', async event => {
-		config = JSON.parse(event.data);
-		activeScreen = SelectIDType;
+		if (event.data.includes('SmileIdentity::HostedWebIntegration')) {
+			config = JSON.parse(event.data);
+			activeScreen = SelectIDType;
 
-		try {
-			productConstraints = await getProductConstraints();
-			initializeSession(productConstraints);
-			getPartnerParams();
+			try {
+				productConstraints = await getProductConstraints();
+				initializeSession(productConstraints);
+				getPartnerParams();
 
-			localStorage.setItem('SmileIdentityConfig', event.data);
-		} catch (e) {
-			throw e;
+				localStorage.setItem('SmileIdentityConfig', event.data);
+			} catch (e) {
+				throw e;
+			}
 		}
 	}, false);
 

--- a/src/js/ekyc.js
+++ b/src/js/ekyc.js
@@ -33,17 +33,19 @@ var eKYC = function eKYC() {
 	}
 
 	window.addEventListener('message', async event => {
-		config = JSON.parse(event.data);
-		activeScreen = SelectIDType;
+		if (event.data.includes('SmileIdentity::HostedWebIntegration')) {
+			config = JSON.parse(event.data);
+			activeScreen = SelectIDType;
 
-		try {
-			productConstraints = await getProductConstraints();
-			initializeSession(productConstraints);
-			getPartnerParams();
+			try {
+				productConstraints = await getProductConstraints();
+				initializeSession(productConstraints);
+				getPartnerParams();
 
-			localStorage.setItem('SmileIdentityConfig', event.data);
-		} catch (e) {
-			throw e;
+				localStorage.setItem('SmileIdentityConfig', event.data);
+			} catch (e) {
+				throw e;
+			}
 		}
 	}, false);
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -122,6 +122,7 @@ var SmileIdentity = function () {
 
 	function publishConfigToIFrame(config) {
 		const targetWindow = document.querySelector("[name='smile-identity-hosted-web-integration']").contentWindow;
+		config.source = 'SmileIdentity::HostedWebIntegration';
 
 		targetWindow.postMessage(JSON.stringify(config), '*');
 	}
@@ -154,8 +155,8 @@ var SmileIdentity = function () {
 						break;
 					default:
 						return;
-					}
-				}, false);
+				}
+			}, false);
 		}
 	}
 


### PR DESCRIPTION
a customer showed that we processed events from multiple sources when
they had multiple event publishers.

in order to restrict this, we had two options:
- `event.origin` which tells us the publisher of the message. we have no
  control over this.
- adding a clear identifier and searching the data sent by it.

in this commit, we have added `SmileIdentity::HostedWebIntegration` as
the clear identifier.

related reading: https://htmldom.dev/communication-between-an-iframe-and-its-parent-window/