### PR TITLE
enh: add `consent_information` to `id_info`

### DIFF
--- a/src/js/biometric-kyc.js
+++ b/src/js/biometric-kyc.js
@@ -212,6 +212,7 @@ var biometricKyc = function biometricKyc() {
 			consent_information = event.detail;
 
 			if (consent_information.consented.personal_details) {
+				id_info.consent_information = consent_information;
 				setActiveScreen(SmartCameraWeb);
 			}
 		}, false);

--- a/src/js/ekyc.js
+++ b/src/js/ekyc.js
@@ -196,6 +196,7 @@ var eKYC = function eKYC() {
 			consent_information = event.detail;
 
 			if (consent_information.consented.personal_details) {
+				id_info.consent_information = consent_information;
 				setActiveScreen(IDInfoForm);
 			}
 		}, false);


### PR DESCRIPTION
add `consent_information` to the `id_info` object sent for `biometric_kyc` and `enhanced_kyc` jobs.

note that the "consent screen" only shows up with the `consent_required` option as documented here: https://docs.smileidentity.com/web-mobile-web/web-integration/usage.

we'll be moving this to be partner config / id type config controlled soon.

you can test on: https://send-consent-smile-hwi.glitch.me