### PR TITLE
Bump smart camera version to beta.17

### DIFF
--- a/src/biometric-kyc.html
+++ b/src/biometric-kyc.html
@@ -23,7 +23,7 @@
 		</noscript>
 		<!-- End Font Loading -->
 
-		<link rel="preload" as='script' href="https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js" />
+		<link rel="preload" as='script' href="https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js" />
 
 		<script
 			src='js/totp-consent-app.min.js'>
@@ -32,7 +32,7 @@
 			src='js/consent-screen.min.js'>
 		</script>
 		<script
-			src='https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js'>
+			src='https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js'>
 		</script>
 	</head>
 

--- a/src/doc-verification.html
+++ b/src/doc-verification.html
@@ -26,10 +26,10 @@
 		<link
 			rel="preload"
 			as='script'
-			href="https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js" />
+			href="https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js" />
 
 		<script
-			src='https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js'>
+			src='https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js'>
 		</script>
 	</head>
 

--- a/src/smartselfie-auth.html
+++ b/src/smartselfie-auth.html
@@ -31,11 +31,11 @@
   <link
       rel="preload"
       as="script"
-      href="https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js"
+      href="https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js"
   />
 
   <script src="js/consent-screen.min.js"></script>
-  <script src="https://cdn.smileidentity.com/js/preview-portrait-capture/smart-camera-web.js"></script>
+  <script src="https://cdn.smileidentity.com/js/v1.0.0-beta.17/smart-camera-web.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR bumps the smart camera version dependency version to v1.0.0-beta.17. This is a follow up to https://github.com/smileidentity/smart-camera-web/pull/25