### PR TITLE
fix permissions for dependabot security updates 

### DIFF
--- a/.github/workflows/share-preview-url.yml
+++ b/.github/workflows/share-preview-url.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3
       - name: get dest dir


### PR DESCRIPTION
This will fix the ci permission error for dependabot security updates 