### PR TITLE
update cypress action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           start: npm start
+          wait-on: 'http://localhost:8000'
       - name: upload test failure artifacts
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
Removes no-op keys from cypress action and updates action to the latest version.

`npm run build` and `npm run build:dist` are run as part of npm start.

## Test Instructions 

Verify that the tests pass. 