### PR TITLE
redesign: rotate active / default button colors

### DIFF
--- a/packages/components/totp-consent/src/TotpConsent.js
+++ b/packages/components/totp-consent/src/TotpConsent.js
@@ -37,8 +37,8 @@ function markup() {
 				--color-richblue: #043C93;
 				--color-theme: ${this.themeColor};
 
-				--color-active: #001096;
-				--color-default: #2D2B2A;
+				--color-active: #2D2B2A;
+				--color-default: #001096;
 				--color-disabled: #848282;
 			}
 

--- a/packages/embed/src/css/styles.css
+++ b/packages/embed/src/css/styles.css
@@ -1,7 +1,7 @@
 :root {
   --flow-space: 1rem;
-  --color-active: #001096;
-  --color-default: #2d2b2a;
+  --color-active: #2d2b2a;
+  --color-default: #001096;
   --color-disabled: #848282;
 }
 

--- a/packages/smart-camera-web/smart-camera-web.js
+++ b/packages/smart-camera-web/smart-camera-web.js
@@ -123,8 +123,8 @@ function scwTemplateString() {
 
   <style>
     :host {
-      --color-active: #001096;
-      --color-default: #2D2B2A;
+      --color-active: #2D2B2A;
+      --color-default: #001096;
       --color-disabled: #848282;
     }
 
@@ -673,7 +673,7 @@ function scwTemplateString() {
         <div class='video'>
         </div>
         <svg id="image-outline" width="215" height="245" viewBox="0 0 215 245" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M210.981 122.838C210.981 188.699 164.248 241.268 107.55 241.268C50.853 241.268 4.12018 188.699 4.12018 122.838C4.12018 56.9763 50.853 4.40771 107.55 4.40771C164.248 4.40771 210.981 56.9763 210.981 122.838Z" stroke="var(--color-active)" stroke-width="7.13965"/>
+          <path d="M210.981 122.838C210.981 188.699 164.248 241.268 107.55 241.268C50.853 241.268 4.12018 188.699 4.12018 122.838C4.12018 56.9763 50.853 4.40771 107.55 4.40771C164.248 4.40771 210.981 56.9763 210.981 122.838Z" stroke="var(--color-default)" stroke-width="7.13965"/>
         </svg>
         <p id='smile-cta' class='color-gray'>SMILE</p>
       </div>


### PR DESCRIPTION
# Test Instructions
- Pull the branch locally, or use the [dev preview link](https://smileid-embed-primary-active-color-inversion.glitch.me)
  - If local, run the following commands
    - `cd packages/embed`
    - `npm ci`
    - `npm run build && npm start`
    - visit http://localhost:8000/biometric_kyc
  - if remote
    - visit any of the pages
- verify that buttons show blue as default color, and black on hover