### PR TITLE
redesign(eSignature): fix copy on signature review screen

### DIFF
--- a/packages/embed/src/e-signature.html
+++ b/packages/embed/src/e-signature.html
@@ -427,7 +427,7 @@
 
         <div class="flow">
           <button data-variant="solid" type="button" id="uploadSignature">
-            Yes, my details are correct
+            Yes, it's correct
             <svg
               aria-hidden="true"
               width="25"
@@ -437,7 +437,7 @@
             >
               <path
                 d="M7 12h11m0 0-4.588-4M18 12l-4.588 4"
-                stroke="#fff"
+                stroke="currentColor"
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -445,13 +445,13 @@
             </svg>
           </button>
           <button
-            style="margin-block-start: 0.5rem"
+            style="margin-block-start: 0.5rem; display: flex !important"
             data-variant="outline"
             type="button"
             class="back-button"
           >
-            No, change them
             <svg
+              style="transform: rotate(.5turn);"
               aria-hidden="true"
               width="25"
               height="24"
@@ -460,12 +460,13 @@
             >
               <path
                 d="M7 12h11m0 0-4.588-4M18 12l-4.588 4"
-                stroke="#fff"
+                stroke="currentColor"
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
             </svg>
+            No, change them
           </button>
         </div>
 


### PR DESCRIPTION
# Steps to Test
- After a successful build
- Visit https://smileid-e-signature.glitch.me
- Walk through the flow
- Verify that the Review Signature screen now shows this:
<img width="456" alt="image" src="https://github.com/smileidentity/web-client/assets/9247442/2fc5de89-ace8-426d-bb7f-76dd4b792cf0">
