### PR TITLE
Add formatting commit hash to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,7 +8,6 @@
 #
 # $ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-# format html 
-b602b3f4e3db250aa8672ab8a321bfc1319f10f3
 # prettier formatting
+b602b3f4e3db250aa8672ab8a321bfc1319f10f3
 da229ce554ebaa192fdb1e16a158aa20fb1d4a5b


### PR DESCRIPTION
This will ignore the formatting commit in git blame. 