### PR TITLE
deploy: switch to oidc as recommended by providers

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,12 +5,14 @@ on:
     types:
       - opened
       - synchronize
+permissions:
+  id-token: write
+  contents: read
 jobs:
   test:
     uses: ./.github/workflows/test.yml
   smart-camera-web:
-    needs:
-      - test
+    needs: [test]
     defaults:
       run:
         working-directory: ./packages/smart-camera-web
@@ -29,22 +31,16 @@ jobs:
         run: >-
           echo "DEST_DIR_SMART_CAMERA_WEB=js/preview-$GITHUB_HEAD_REF" >>
           "$GITHUB_ENV"
-      - name: deploy preview to s3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          args: >-
-            --follow-symlinks --delete --exclude '*' --include
-            'smart-camera-web.js'
-        env:
-          AWS_S3_BUCKET: '${{ secrets.AWS_S3_BUCKET }}'
-          AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-          AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-          AWS_REGION: '${{ secrets.AWS_REGION }}'
-          SOURCE_DIR: ./packages/smart-camera-web
-          DEST_DIR: '${{ env.DEST_DIR_SMART_CAMERA_WEB }}'
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy preview to s3
+        run: |
+          aws s3 sync --follow-symlinks --delete --exclude '*' --include 'smart-camera-web.js' . s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.DEST_DIR_SMART_CAMERA_WEB }}
   embed:
-    needs:
-      - test
+    needs: [test]
     defaults:
       run:
         working-directory: ./packages/embed
@@ -57,19 +53,17 @@ jobs:
       - name: install dependencies
         run: npm ci
       - name: build application
-        run: 'npm run build && npm run build:dist'
+        env:
+          SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
+        run: npm run build && npm run build:dist
       - name: set destination directory
         id: set_dest_dir_hosted_web
         run: echo "DEST_DIR_EMBED=inline/preview-$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
-      - name: deploy preview to s3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          args: '--follow-symlinks --delete'
-        env:
-          AWS_S3_BUCKET: '${{ secrets.AWS_S3_BUCKET }}'
-          AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-          AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-          AWS_REGION: '${{ secrets.AWS_REGION }}'
-          SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
-          SOURCE_DIR: ./packages/embed/dist
-          DEST_DIR: '${{ env.DEST_DIR_EMBED }}'
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy preview to s3
+        run: |
+          aws s3 sync --follow-symlinks --delete dist s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.DEST_DIR_EMBED }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,6 +2,9 @@ name: deploy staging
 on:
   push:
     branches: [main]
+permissions:
+  id-token: write
+  contents: read
 jobs:
   test:
     uses: ./.github/workflows/test.yml
@@ -15,19 +18,14 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-      - name: deploy to staging to s3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          args: >-
-            --follow-symlinks --delete --exclude '*' --include
-            'smart-camera-web.js'
-        env:
-          AWS_S3_BUCKET: '${{ secrets.AWS_S3_BUCKET }}'
-          AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-          AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-          AWS_REGION: '${{ secrets.AWS_REGION }}'
-          SOURCE_DIR: './packages/smart-camera-web'
-          DEST_DIR: 'js/staging'
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy staging to s3
+        run: |
+          aws s3 sync --follow-symlinks --delete --exclude '*' --include 'smart-camera-web.js' . s3://${{ secrets.AWS_S3_BUCKET }}/js/staging
   embed:
     needs: [test]
     runs-on: ubuntu-latest
@@ -42,17 +40,15 @@ jobs:
         uses: actions/setup-node@v4
       - name: install dependencies
         run: npm ci
-      - name: build site
-        run: npm run build && npm run build:dist
-      - name: deploy to s3 / cloudfront
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete
+      - name: build application
         env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
           SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
-          SOURCE_DIR: './packages/embed/dist'
-          DEST_DIR: 'inline/staging'
+        run: npm run build && npm run build:dist
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy staging to s3
+        run: |
+          aws s3 sync --follow-symlinks --delete dist s3://${{ secrets.AWS_S3_BUCKET }}/inline/staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: deploy
 on:
   push:
     tags: v*
+permissions:
+  id-token: write
+  contents: read
 jobs:
   test:
     uses: ./.github/workflows/test.yml
@@ -26,17 +29,14 @@ jobs:
           TAG: ${{ steps.package-version.outputs.current-version }}
         run: |
           echo "DEST_DIR_SMART_CAMERA_WEB=js/v$TAG" >> $GITHUB_OUTPUT
-      - name: deploy to s3 / cloudfront
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          args: --follow-symlinks --delete --exclude '*' --include 'smart-camera-web.js'
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: ./packages/smart-camera-web
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          DEST_DIR: ${{ steps.set_destination.outputs.DEST_DIR_SMART_CAMERA_WEB }}
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy to s3 / cloudfront
+        run: |
+          aws s3 sync --follow-symlinks --delete --exclude '*' --include 'smart-camera-web.js' . s3://${{ secrets.AWS_S3_BUCKET }}/${{ steps.set_destination.outputs.DEST_DIR_SMART_CAMERA_WEB }}
   embed:
     needs: [test]
     runs-on: ubuntu-latest
@@ -51,17 +51,15 @@ jobs:
         uses: actions/setup-node@v4
       - name: install dependencies
         run: npm ci
-      - name: build site
-        run: npm run build && npm run build:dist
-      - name: deploy to s3 / cloudfront
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete
+      - name: build application
         env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
           SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
-          SOURCE_DIR: './packages/embed/dist'
-          DEST_DIR: 'inline/v1'
+        run: npm run build && npm run build:dist
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: deploy to s3 / cloudfront
+        run: |
+          aws s3 sync --follow-symlinks --delete dist s3://${{ secrets.AWS_S3_BUCKET }}/inline/v1


### PR DESCRIPTION
This change comes as a result of a past exploration where the SmileLinks application had failed
builds for dependabot.

[AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html?icmpid=docs_iam_help_panel#bp-workloads-use-roles) / [Github](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) recommend using OpenID Connect(OIDC) for deployments.

This is in contrast to the implementation using IAM Users who have less fine-grained access.

Making this change resulted in two other changes:
- switching to the aws script from [s3-sync-action](https://github.com/marketplace/actions/s3-sync) due to this [unresolved issue](https://github.com/jakejarvis/s3-sync-action/issues/14)
- fixing a mis-configured `SENTRY_AUTH_TOKEN`, which was in the deploy step, and not the build step.

## Steps to Test
- Deploy as normal

## Deploy Steps
- Deploy as normal (verify no failures)
- Delete AWS IAM Secrets