### PR TITLE
[smart-camera-web] Reduce test run time

### DIFF
--- a/packages/smart-camera-web/cypress/e2e/skip-back-of-id.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/skip-back-of-id.cy.js
@@ -5,6 +5,7 @@ context('SmartCameraWeb - Skip Back of ID Document Capture', () => {
 
   context('when a document type does not exist', () => {
     it('should switch from the back of ID entry screen to the thanks screen on clicking the "Skip this step" button', () => {
+      cy.clock();
       cy.get('smart-camera-web')
         .shadow()
         .find('#request-camera-access')
@@ -12,7 +13,7 @@ context('SmartCameraWeb - Skip Back of ID Document Capture', () => {
 
       cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-      cy.wait(8000);
+      cy.tick(8000);
 
       cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -65,6 +66,7 @@ context('SmartCameraWeb - Skip Back of ID Document Capture', () => {
     });
 
     it('should not show the "skip this step" button', () => {
+      cy.clock();
       cy.get('smart-camera-web')
         .shadow()
         .find('#request-camera-access')
@@ -72,7 +74,7 @@ context('SmartCameraWeb - Skip Back of ID Document Capture', () => {
 
       cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-      cy.wait(8000);
+      cy.tick(8000);
 
       cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 

--- a/packages/smart-camera-web/cypress/e2e/smart-camera-web-back-press.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/smart-camera-web-back-press.cy.js
@@ -50,11 +50,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the idEntryScreen to the selfieScreen on clicking the back button', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -82,11 +83,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the idCameraScreen to the idEntryScreen on clicking the "back" button', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -119,11 +121,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the backOfIdEntryScreen to the idReviewScreen when the back button is clicked', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -167,11 +170,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the backOfIdCameraScreen to the backOfIdEntryScreen on clicking the "back" button', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -241,11 +245,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in selfie review screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#review-screen-close').click();
 
@@ -253,11 +258,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id entry screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -272,11 +278,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id camera screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -296,11 +303,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id review screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -329,11 +337,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id back entry screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -369,11 +378,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id back camera screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -414,11 +424,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should navigate to "closed" when close button is pressed in id back review screen', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 

--- a/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-back-of-id-portrait.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-back-of-id-portrait.cy.js
@@ -144,11 +144,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo when "capture-id-image" is clicked, and move to the "id-review-screen"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -188,11 +189,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the back of ID camera screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -261,11 +263,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo, and move from the back of ID camera screen to the back of ID review screen on clicking the "capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -334,11 +337,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the back of ID review screen to the back of ID camera screen on clicking the "Re-Capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -444,11 +448,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the back of ID review screen to the thanks screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 

--- a/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-back-of-id.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-back-of-id.cy.js
@@ -142,11 +142,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo when "capture-id-image" is clicked, and move to the "id-review-screen"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -186,11 +187,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the back of ID camera screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -259,11 +261,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo, and move from the back of ID camera screen to the back of ID review screen on clicking the "capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -332,11 +335,12 @@ context('SmartCameraWeb', () => {
   });
 
   it.only('should switch from the back of ID review screen to the back of ID camera screen on clicking the "Re-Capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -442,11 +446,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the back of ID review screen to the thanks screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 

--- a/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-id-portrait.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-id-portrait.cy.js
@@ -92,11 +92,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the id camera screen on clicking "Yes, use this one"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -144,11 +145,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo when "capture-id-image" is clicked, and move to the "id-review-screen"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -188,11 +190,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the id review screen back to the camera screen on clicking the "Re-Capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -261,11 +264,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the id camera screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 

--- a/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-id.cy.js
+++ b/packages/smart-camera-web/cypress/e2e/smart-camera-web-with-id.cy.js
@@ -71,11 +71,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen back to the camera screen on clicking "Re-take selfie"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#restart-image-capture').click();
 
@@ -91,11 +92,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the id camera screen on clicking "Yes, use this one"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -141,11 +143,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should capture a photo when "capture-id-image" is clicked, and move to the "id-review-screen"', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -185,11 +188,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the id review screen back to the camera screen on clicking the "Re-Capture" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 
@@ -256,11 +260,12 @@ context('SmartCameraWeb', () => {
   });
 
   it('should switch from the review screen to the id camera screen on clicking the "Approve" icon', () => {
+    cy.clock();
     cy.get('smart-camera-web').shadow().find('#request-camera-access').click();
 
     cy.get('smart-camera-web').shadow().find('#start-image-capture').click();
 
-    cy.wait(8000);
+    cy.tick(8000);
 
     cy.get('smart-camera-web').shadow().find('#select-selfie').click();
 


### PR DESCRIPTION
This reduces the run time for smart camera web.
We stub the wait time for selfie capture when test is not focused on selfie capture

# Before
<img width="844" alt="Screenshot 2024-08-01 at 12 33 29 PM" src="https://github.com/user-attachments/assets/5b848f9d-97de-4547-9129-dcc3f7b87070">


# After
<img width="844" alt="Screenshot 2024-08-01 at 12 32 57 PM" src="https://github.com/user-attachments/assets/18b39393-2b33-4c10-8dd2-3df333839691">

