### PR TITLE
[Embed]Add new component auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new designs to smart selfie authentication
+
 ## [1.3.5] - 2024-07-12
 
 ### Changed

--- a/example/script.js
+++ b/example/script.js
@@ -83,7 +83,7 @@ export default function setupForm() {
             name: 'Demo Account',
             logo_url: 'https://via.placeholder.com/50/000000/FFFFFF?text=DA',
             policy_url: 'https://smileidentity.com/privacy-privacy',
-            theme_color: '#000',
+            theme_color: '#96002d',
           },
           onSuccess: () => {
             resetButton();

--- a/packages/embed/cypress/pages/smartselfie-new-design.html
+++ b/packages/embed/cypress/pages/smartselfie-new-design.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        max-width: 100%;
+        min-height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <script src="js/script.min.js"></script>
+
+    <script>
+      SmileIdentity({
+        use_new_component: true,
+        token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJ0bmVyX3BhcmFtcyI6eyJ1c2VyX2lkIjoid2ViLXRva2VuLXRlc3QtdXNlci0xMDEiLCJqb2JfaWQiOiJ3ZWItdG9rZW4tam9iLTIzMDAiLCJqb2JfdHlwZSI6NH0sImNhbGxiYWNrX3VybCI6Imh0dHBzOi8vd2ViaG9vay5zaXRlLzFhYWE3YTdiLWFjY2ItNDBhYy04NjQzLWZkOGE4NzAzZTliZSIsImlhdCI6MTY0ODIzNTA0NCwiZXhwIjoxNjQ5ODgzMjcyfQ.FNqqYIda63uEd2pMSSnDcWmm4eXPvRRpuV9qJggGejc',
+        product: 'smartselfie',
+        callback_url:
+          'https://webhook.site/1aaa7a7b-accb-40ac-8643-fd8a8703e9be',
+        environment: 'sandbox',
+        consent_required: {
+          NG: ['BVN'],
+        },
+        partner_details: {
+          name: 'Test Org',
+          logo_url: 'https://portal.usesmileid.com/favicon.ico',
+          partner_id: '212',
+          policy_url: 'https://usesmileid.com/privacy-policy',
+          theme_color: '#000',
+        },
+        onSuccess: () => {},
+        onClose: () => {},
+      });
+    </script>
+  </body>
+</html>

--- a/packages/embed/cypress/support/commands.js
+++ b/packages/embed/cypress/support/commands.js
@@ -257,3 +257,55 @@ Cypress.Commands.add('navigateThroughCameraScreens', () => {
     .find('#select-selfie')
     .click();
 });
+
+Cypress.Commands.add('navigateThroughNewCameraScreens', () => {
+  cy.log('SmartCameraWeb: disable image tests');
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .invoke('attr', 'disable-image-tests', 'true');
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .shadow()
+    .find('#allow')
+    .click();
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .should('not.be.visible');
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture')
+    .should('be.visible');
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture')
+    .shadow()
+    .should('contain.text', 'Take a Selfie');
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture')
+    .shadow()
+    .find('#start-image-capture')
+    .click();
+
+  cy.wait(8000);
+
+  cy.getIFrameBody()
+    .find('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-review')
+    .shadow()
+    .find('#select-id-image')
+    .click();
+});

--- a/packages/embed/cypress/tests/smartselfie-auth-new-design.cy.cjs
+++ b/packages/embed/cypress/tests/smartselfie-auth-new-design.cy.cjs
@@ -1,0 +1,77 @@
+describe('smartselfie authentication', () => {
+  beforeEach(() => {
+    cy.visit('/smartselfie-new-design');
+
+    cy.getIFrameBody().should('be.visible');
+
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '*upload*',
+      },
+      {
+        upload_url:
+          'https://smile-uploads-development01.s3.us-west-2.amazonaws.com/videos/212/212-0000060103-0gdzke3mdtlco5k0sdfh6vifzcrd3n/smartselfie.zip',
+      },
+    ).as('getUploadURL');
+  });
+
+  describe('when a successful upload happens', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: 'https://smile-uploads-development01.s3.us-west-2.amazonaws.com/videos/212/212-0000060103-0gdzke3mdtlco5k0sdfh6vifzcrd3n/smartselfie.zip',
+        },
+        {
+          statusCode: 200,
+        },
+      ).as('successfulUpload');
+      cy.navigateThroughNewCameraScreens();
+    });
+
+    it('should show the completion screen', () => {
+      cy.wait('@getUploadURL');
+
+      cy.wait('@successfulUpload');
+      cy.getIFrameBody().find('#complete-screen').should('be.visible');
+    });
+  });
+
+  describe('when the upload fails', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: 'https://smile-uploads-development01.s3.us-west-2.amazonaws.com/videos/212/212-0000060103-0gdzke3mdtlco5k0sdfh6vifzcrd3n/smartselfie.zip',
+        },
+        {
+          statusCode: 412,
+        },
+      ).as('failedUploadRequest');
+      cy.navigateThroughNewCameraScreens();
+    });
+
+    it('should show the upload failure screen', () => {
+      cy.wait('@getUploadURL');
+
+      cy.getIFrameBody()
+        .find('#upload-progress-screen')
+        .should('not.be.visible');
+
+      cy.wait('@failedUploadRequest');
+
+      cy.getIFrameBody().find('#upload-failure-screen').should('be.visible');
+    });
+
+    it('should should retry upload when "try again" button is clicked', () => {
+      cy.wait('@getUploadURL');
+
+      cy.wait('@failedUploadRequest');
+
+      cy.getIFrameBody().find('#retry-upload').click();
+
+      cy.wait('@failedUploadRequest');
+    });
+  });
+});

--- a/packages/embed/src/js/smartselfie-auth.js
+++ b/packages/embed/src/js/smartselfie-auth.js
@@ -1,4 +1,3 @@
-import '@smile_identity/smart-camera-web';
 import JSZip from 'jszip';
 import { version as sdkVersion } from '../../package.json';
 
@@ -57,6 +56,12 @@ import { version as sdkVersion } from '../../package.json';
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        if (config.use_new_component) {
+          import('@smileid/web-components/smart-camera-web');
+          CloseIframeButton.setAttribute('hidden', true);
+        } else {
+          import('@smile_identity/smart-camera-web');
+        }
         partner_params = getPartnerParams();
         id_info = {};
         setActiveScreen(SmartCameraWeb);
@@ -77,6 +82,16 @@ import { version as sdkVersion } from '../../package.json';
     false,
   );
 
+  SmartCameraWeb.addEventListener(
+    'smart-camera-web.publish',
+    (event) => {
+      images = event.detail.images;
+      setActiveScreen(UploadProgressScreen);
+      handleFormSubmit(event);
+    },
+    false,
+  );
+
   RetryUploadButton.addEventListener(
     'click',
     () => {
@@ -85,8 +100,24 @@ import { version as sdkVersion } from '../../package.json';
     false,
   );
 
-  CloseIframeButton.addEventListener(
+  CloseIframeButton?.addEventListener(
     'click',
+    () => {
+      closeWindow(true);
+    },
+    false,
+  );
+
+  SmartCameraWeb.addEventListener(
+    'smart-camera-web.close',
+    () => {
+      closeWindow(true);
+    },
+    false,
+  );
+
+  SmartCameraWeb.addEventListener(
+    'smart-camera-web.cancelled',
     () => {
       closeWindow(true);
     },

--- a/packages/web-components/components/selfie/src/selfie-capture/SelfieCapture.js
+++ b/packages/web-components/components/selfie/src/selfie-capture/SelfieCapture.js
@@ -841,6 +841,7 @@ class SelfieCaptureScreen extends HTMLElement {
     return [
       'data-camera-error',
       'data-camera-ready',
+      'disable-image-tests',
       'hidden',
       'hide-back-to-host',
       'show-navigation',

--- a/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
+++ b/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
@@ -61,16 +61,18 @@ class SmartCameraWeb extends HTMLElement {
 
   static get observedAttributes() {
     return [
+      'disable-image-tests',
       'document-capture-modes',
       'document-type',
+      'hide-back-of-id',
       'hide-back-to-host',
       'show-navigation',
-      'hide-back-of-id',
     ];
   }
 
   attributeChangedCallback(name) {
     switch (name) {
+      case 'disable-image-tests':
       case 'document-capture-modes':
       case 'document-type':
       case 'hide-back-of-id':


### PR DESCRIPTION
This adds the new designs to the smart selfie registration and smart selfie auth in the embed.


# Test Instructions
Run the example app with `use_new_component` to true
Run a smart selfie registration job
This should use the new designs
Confirm the job appears on the portal.