### PR TITLE
Fix: hide id document frame when checking permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix: Hide the document video when checking permission
+- Update dev dependencies
 
 ## [1.4.0] - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2024-09-03
+
+### Changed
+
+- Fix: Hide the document video when checking permission
+
 ## [1.4.0] - 2024-08-30
 
 ### Added

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A collection of SmileID browser clients and components",
   "main": "index.js",
   "private": true,

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/embed",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Self Hosted Integration for Smile Identity on the Web",
   "private": true,
   "main": "inline.js",

--- a/packages/smart-camera-web/package.json
+++ b/packages/smart-camera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smile_identity/smart-camera-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "WebComponent for smartly capturing images on the web, for use with SmileIdentity",
   "main": "smart-camera-web.js",
   "scripts": {

--- a/packages/web-components/components/document/src/document-capture/DocumentCapture.js
+++ b/packages/web-components/components/document/src/document-capture/DocumentCapture.js
@@ -373,6 +373,9 @@ class DocumentCapture extends HTMLElement {
       this.shadowRoot.querySelector('#loader').hidden = true;
       this.shadowRoot.querySelector('.id-video').hidden = false;
       this.shadowRoot.querySelector('.actions').hidden = false;
+      if (!videoExists) {
+        videoContainer.prepend(canvas);
+      }
     };
 
     const onVideoStart = () => {
@@ -398,10 +401,6 @@ class DocumentCapture extends HTMLElement {
     };
 
     video.addEventListener('playing', onVideoStart);
-
-    if (!videoExists) {
-      videoContainer.prepend(canvas);
-    }
 
     this._IDStream = stream;
     this._IDVideo = video;

--- a/packages/web-components/components/signature-pad/package.json
+++ b/packages/web-components/components/signature-pad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/signature-pad",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": "true",
   "exports": {
     ".": "./index.js"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web-components",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": "true",
   "exports": {
     ".": "./index.js",


### PR DESCRIPTION
When checking for permission, the id document shows up together with the loader.
This hides the frame until the permission is available.
