### PR TITLE
Fix closing pages

### DIFF
--- a/example/script.js
+++ b/example/script.js
@@ -74,13 +74,13 @@ export default function setupForm() {
           environment,
           use_new_component: true,
           //demo_mode: true,
-          // previewBVNMFA: true,
+          previewBVNMFA: true,
           hide_attribution: true,
           document_capture_modes: ['camera', 'upload'],
           allow_agent_mode: true,
-          // consent_required: {
-          //   NG: ['BVN'],
-          // },
+          consent_required: {
+            NG: ['BVN'],
+          },
           partner_details: {
             partner_id,
             signature,

--- a/example/script.js
+++ b/example/script.js
@@ -78,6 +78,9 @@ export default function setupForm() {
           hide_attribution: true,
           document_capture_modes: ['camera', 'upload'],
           allow_agent_mode: true,
+          // consent_required: {
+          //   NG: ['BVN'],
+          // },
           partner_details: {
             partner_id,
             signature,

--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -466,7 +466,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,
@@ -475,7 +478,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        referenceWindow.postMessage(
+        (referenceWindow.parent || referenceWindow).postMessage(
           'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
           '*',
         );
@@ -855,10 +858,13 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    referenceWindow.postMessage(message, '*');
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -466,10 +466,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied',
-          '*',
-        );
+        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
         closeWindow();
       },
       false,
@@ -478,7 +475,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        (referenceWindow.parent || referenceWindow).postMessage(
+        referenceWindow.postMessage(
           'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
           '*',
         );
@@ -858,13 +855,14 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
+    [referenceWindow.parent, referenceWindow].forEach((win) => {
+      win.postMessage(message, '*');
+    });
   }
 
   function handleSuccess() {
-    (referenceWindow.parent || referenceWindow).postMessage(
-      'SmileIdentity::Success',
-      '*',
-    );
+    [referenceWindow.parent, referenceWindow].forEach((win) => {
+      win.postMessage('SmileIdentity::Success', '*');
+    });
   }
 })();

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -426,7 +426,7 @@ import { version as sdkVersion } from '../../package.json';
   SmartCameraWeb.addEventListener(
     'smart-camera-web.close',
     () => {
-      closeWindow();
+      closeWindow(true);
     },
     false,
   );

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -560,7 +560,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,
@@ -569,7 +572,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        referenceWindow.postMessage(
+        (referenceWindow.parent || referenceWindow).postMessage(
           'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
           '*',
         );
@@ -950,10 +953,13 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    referenceWindow.postMessage(message, '*');
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -560,10 +560,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied',
-          '*',
-        );
+        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
         closeWindow();
       },
       false,
@@ -953,7 +950,9 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
+    [referenceWindow.parent, referenceWindow].forEach((win) =>
+      win.postMessage(message, '*'),
+    );
   }
 
   function handleSuccess() {

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -534,7 +534,7 @@ import { version as sdkVersion } from '../../package.json';
     false,
   );
 
-  CloseIframeButtons.forEach((button) => {
+  CloseIframeButtons?.forEach((button) => {
     button.addEventListener(
       'click',
       () => {

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -733,6 +733,7 @@ import { version as sdkVersion } from '../../package.json';
   }
 
   function handleSuccess() {
+    console.log('close success');
     referenceWindow.postMessage('SmileIdentity::Success', '*');
   }
 })();

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -729,6 +729,8 @@ import { version as sdkVersion } from '../../package.json';
   }
 
   function closeWindow() {
+    console.log('close window');
+    
     referenceWindow.postMessage('SmileIdentity::Close', '*');
   }
 

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -513,7 +513,7 @@ import { version as sdkVersion } from '../../package.json';
   SmartCameraWeb.addEventListener(
     'close',
     () => {
-      closeWindow();
+      closeWindow(true);
     },
     false,
   );
@@ -521,7 +521,7 @@ import { version as sdkVersion } from '../../package.json';
   SmartCameraWeb.addEventListener(
     'smart-camera-web.close',
     () => {
-      closeWindow();
+      closeWindow(true);
     },
     false,
   );
@@ -538,7 +538,7 @@ import { version as sdkVersion } from '../../package.json';
     button.addEventListener(
       'click',
       () => {
-        closeWindow();
+        closeWindow(true);
       },
       false,
     );
@@ -728,14 +728,17 @@ import { version as sdkVersion } from '../../package.json';
     return fileUploaded;
   }
 
-  function closeWindow() {
-    console.log('close window');
-    
-    referenceWindow.postMessage('SmileIdentity::Close', '*');
+  function closeWindow(userTriggered) {
+    const message = userTriggered
+      ? 'SmileIdentity::Close'
+      : 'SmileIdentity::Close::System';
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   function handleSuccess() {
-    console.log('close success');
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/embed/src/js/e-signature.js
+++ b/packages/embed/src/js/e-signature.js
@@ -26,7 +26,7 @@ function getHumanSize(numberOfBytes) {
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    referenceWindow.postMessage(message, '*');
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   // NOTE: In order to support prior integrations, we have `live` and
@@ -44,11 +44,14 @@ function getHumanSize(numberOfBytes) {
   referenceWindow.postMessage('SmileIdentity::ChildPageReady', '*');
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 
   function handleBadDocuments(error) {
-    referenceWindow.postMessage(
+    (referenceWindow.parent || referenceWindow).postMessage(
       {
         message: 'SmileIdentity::Error',
         data: {

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -462,10 +462,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied',
-          '*',
-        );
+        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
         closeWindow();
       },
       false,
@@ -858,7 +855,9 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
+    [referenceWindow.parent, referenceWindow].forEach((win) => {
+      win.postMessage(message, '*');
+    });
   }
 
   function handleSuccess() {

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -462,7 +462,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,
@@ -471,7 +474,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        referenceWindow.postMessage(
+        (referenceWindow.parent || referenceWindow).postMessage(
           'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
           '*',
         );
@@ -855,10 +858,13 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    referenceWindow.postMessage(message, '*');
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/embed/src/js/enhanced-document-verification.js
+++ b/packages/embed/src/js/enhanced-document-verification.js
@@ -531,10 +531,16 @@ import { version as sdkVersion } from '../../package.json';
   }
 
   function closeWindow() {
-    referenceWindow.postMessage('SmileIdentity::Close', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Close',
+      '*',
+    );
   }
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -295,7 +295,10 @@
   }
 
   function closeWindow() {
-    referenceWindow.postMessage('SmileIdentity::Close', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Close',
+      '*',
+    );
   }
 
   function publishMessage() {

--- a/packages/embed/src/js/smartselfie-auth.js
+++ b/packages/embed/src/js/smartselfie-auth.js
@@ -317,10 +317,13 @@ import { version as sdkVersion } from '../../package.json';
     const message = userTriggered
       ? 'SmileIdentity::Close'
       : 'SmileIdentity::Close::System';
-    referenceWindow.postMessage(message, '*');
+    (referenceWindow.parent || referenceWindow).postMessage(message, '*');
   }
 
   function handleSuccess() {
-    referenceWindow.postMessage('SmileIdentity::Success', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Success',
+      '*',
+    );
   }
 })();

--- a/packages/web-components/components/totp-consent/src/TotpConsent.js
+++ b/packages/web-components/components/totp-consent/src/TotpConsent.js
@@ -625,10 +625,12 @@ class TotpConsent extends HTMLElement {
 
   closeWindow() {
     const referenceWindow = window.parent;
-    (referenceWindow.parent || referenceWindow).postMessage(
-      'SmileIdentity::Close',
-      '*',
-    );
+    [referenceWindow.parent, referenceWindow].forEach((win) => {
+      win.postMessage(
+        'SmileIdentity::Close',
+        '*',
+      );
+    });
   }
 
   handleBackClick() {

--- a/packages/web-components/components/totp-consent/src/TotpConsent.js
+++ b/packages/web-components/components/totp-consent/src/TotpConsent.js
@@ -625,7 +625,10 @@ class TotpConsent extends HTMLElement {
 
   closeWindow() {
     const referenceWindow = window.parent;
-    (referenceWindow.parent || referenceWindow).postMessage('SmileIdentity::Close', '*');
+    (referenceWindow.parent || referenceWindow).postMessage(
+      'SmileIdentity::Close',
+      '*',
+    );
   }
 
   handleBackClick() {

--- a/packages/web-components/components/totp-consent/src/TotpConsent.js
+++ b/packages/web-components/components/totp-consent/src/TotpConsent.js
@@ -626,10 +626,7 @@ class TotpConsent extends HTMLElement {
   closeWindow() {
     const referenceWindow = window.parent;
     [referenceWindow.parent, referenceWindow].forEach((win) => {
-      win.postMessage(
-        'SmileIdentity::Close',
-        '*',
-      );
+      win.postMessage('SmileIdentity::Close', '*');
     });
   }
 

--- a/packages/web-components/components/totp-consent/src/TotpConsent.js
+++ b/packages/web-components/components/totp-consent/src/TotpConsent.js
@@ -624,8 +624,8 @@ class TotpConsent extends HTMLElement {
   }
 
   closeWindow() {
-    const referenceWindow = this.window.parent;
-    referenceWindow.postMessage('SmileIdentity::Close', '*');
+    const referenceWindow = window.parent;
+    (referenceWindow.parent || referenceWindow).postMessage('SmileIdentity::Close', '*');
   }
 
   handleBackClick() {


### PR DESCRIPTION
# Summary
On smile links, the parent window does not receive the messages sent from the web client.
This fix accesses the parent window of the web client iframe parent to send the message.

# Test Instructions
- Run the example app, try different products and screens
- Close the different screens and the pages should close accordingly
- Complete jobs for the different products and the page should close accordingly

Smile links

- Deploy https://github.com/smileidentity/smile-links/pull/235
- Create a link with redirect url on dev
- Complete different jobs and the page should redirect