### PR TITLE
This fixes onError not propagated to grandparent of the window

### DIFF
--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -466,10 +466,9 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied',
-          '*',
-        );
+        [referenceWindow.parent, referenceWindow].forEach((win) => {
+          win.postMessage('SmileIdentity::ConsentDenied', '*');
+        });
         closeWindow();
       },
       false,
@@ -478,10 +477,12 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
-          '*',
-        );
+        [referenceWindow.parent, referenceWindow].forEach((win) => {
+          win.postMessage(
+            'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
+            '*',
+          );
+        });
         closeWindow();
       },
       false,

--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -466,7 +466,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,
@@ -475,7 +478,7 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        referenceWindow.postMessage(
+        (referenceWindow.parent || referenceWindow).postMessage(
           'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
           '*',
         );

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -560,7 +560,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -462,7 +462,10 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        referenceWindow.postMessage('SmileIdentity::ConsentDenied', '*');
+        (referenceWindow.parent || referenceWindow).postMessage(
+          'SmileIdentity::ConsentDenied',
+          '*',
+        );
         closeWindow();
       },
       false,

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -462,10 +462,9 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.denied',
       () => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied',
-          '*',
-        );
+        [referenceWindow.parent || referenceWindow].forEach((win) => {
+          win.postMessage('SmileIdentity::ConsentDenied', '*');
+        });
         closeWindow();
       },
       false,
@@ -474,10 +473,12 @@ import { version as sdkVersion } from '../../package.json';
     EndUserConsent.addEventListener(
       'end-user-consent.totp.denied.contact-methods-outdated',
       (event) => {
-        (referenceWindow.parent || referenceWindow).postMessage(
-          'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
-          '*',
-        );
+        [referenceWindow.parent || referenceWindow].forEach((win) => {
+          win.postMessage(
+            'SmileIdentity::ConsentDenied::TOTP::ContactMethodsOutdated',
+            '*',
+          );
+        });
         closeWindow();
       },
       false,
@@ -864,9 +865,8 @@ import { version as sdkVersion } from '../../package.json';
   }
 
   function handleSuccess() {
-    (referenceWindow.parent || referenceWindow).postMessage(
-      'SmileIdentity::Success',
-      '*',
-    );
+    [referenceWindow.parent, referenceWindow].forEach((win) => {
+      win.postMessage('SmileIdentity::Success', '*');
+    });
   }
 })();

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -113,8 +113,8 @@
 
     if (!validIdType) {
       const legacyValidIdType =
-        legacyProductConstraints.doc_verification[country].id_types[id_type] ||
-        legacyProductConstraints.enhanced_kyc[country].id_types[id_type];
+        legacyProductConstraints.doc_verification[country]?.id_types[id_type] ||
+        legacyProductConstraints.enhanced_kyc[country]?.id_types[id_type];
       if (legacyValidIdType) {
         validIdType = {
           name: legacyValidIdType.label,


### PR DESCRIPTION
In smile links, the onError is not called due to the grandparent of the window not receiving the consent denied message.

This also adds optional chaining to the legacy product constraint check.


# Testing 
run the example up
Select enhanced or basic kyc
Select NG then bvn
Cancel the consent
The screen should close