### PR TITLE
[web-components]Fix document capture hide attribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16862,7 +16862,7 @@
       "name": "@smileid/embed",
       "version": "1.4.4",
       "dependencies": {
-        "@sentry/browser": "^8.32.0",
+        "@sentry/browser": "^8.33.0",
         "@sentry/esbuild-plugin": "^2.22.3",
         "@smile_identity/smart-camera-web": "file:../smart-camera-web",
         "@smileid/web-components": "^1.0.0",

--- a/packages/web-components/components/document/src/DocumentCaptureScreens.js
+++ b/packages/web-components/components/document/src/DocumentCaptureScreens.js
@@ -34,20 +34,23 @@ class DocumentCaptureScreens extends HTMLElement {
     this.innerHTML = `
       ${styles(this.themeColor)}
       <div>
-      <document-capture-instructions theme-color='${this.themeColor}' id='document-capture-instructions-front' ${this.title} ${this.documentCaptureModes} ${this.showNavigation} ${this.hideInstructions ? 'hidden' : ''}></document-capture-instructions>
+      <document-capture-instructions theme-color='${this.themeColor}' id='document-capture-instructions-front' ${this.title}
+      ${this.documentCaptureModes} ${this.showNavigation} ${this.hideInstructions ? 'hidden' : ''}
+      ${this.hideAttribution}
+      ></document-capture-instructions>
       <document-capture id='document-capture-front' side-of-id='Front'
-      ${this.title} ${this.showNavigation} ${this.hideInstructions ? '' : 'hidden'} 
+      ${this.title} ${this.showNavigation} ${this.hideInstructions ? '' : 'hidden'} ${this.hideAttribution}
       ${this.documentCaptureModes} ${this.documentType} theme-color='${this.themeColor}'
       ></document-capture>
       <document-capture-instructions id='document-capture-instructions-back' side-of-id='Back' title='Submit Back of ID'
-       ${this.documentCaptureModes} ${this.showNavigation} theme-color='${this.themeColor}' hidden
+       ${this.documentCaptureModes} ${this.showNavigation} theme-color='${this.themeColor}' ${this.hideAttribution} hidden
        ></document-capture-instructions>
       <document-capture id='document-capture-back' side-of-id='Back' ${this.title} ${this.showNavigation}
-      ${this.documentCaptureModes} theme-color='${this.themeColor}'
+      ${this.documentCaptureModes} theme-color='${this.themeColor}' ${this.hideAttribution}
       hidden 
       ></document-capture>
-      <document-capture-review id='front-of-document-capture-review' theme-color='${this.themeColor}' hidden></document-capture-review>
-      <document-capture-review id='back-of-document-capture-review' theme-color='${this.themeColor}' hidden></document-capture-review>
+      <document-capture-review id='front-of-document-capture-review' theme-color='${this.themeColor}' ${this.hideAttribution} hidden></document-capture-review>
+      <document-capture-review id='back-of-document-capture-review' theme-color='${this.themeColor}' ${this.hideAttribution} hidden></document-capture-review>
       </div>
     `;
 
@@ -292,6 +295,10 @@ class DocumentCaptureScreens extends HTMLElement {
     return this.hasAttribute('document-type')
       ? `document-type='${this.getAttribute('document-type')}'`
       : '';
+  }
+
+  get hideAttribution() {
+    return this.hasAttribute('hide-attribution') ? 'hide-attribution' : '';
   }
 
   get themeColor() {

--- a/packages/web-components/components/document/src/DocumentCaptureScreens.stories.js
+++ b/packages/web-components/components/document/src/DocumentCaptureScreens.stories.js
@@ -2,9 +2,11 @@ import './index';
 
 const meta = {
   args: {
+    'hide-attribution': false,
     'theme-color': '#001096',
   },
   argTypes: {
+    'hide-attribution': { control: 'boolean' },
     'theme-color': { control: 'color' },
   },
   component: 'document-capture-screens',
@@ -14,35 +16,35 @@ export default meta;
 
 export const DocumentCapture = {
   render: (args) => `
-        <document-capture-screens theme-color='${args['theme-color']}'>
+        <document-capture-screens theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </document-capture-screens>
     `,
 };
 
 export const DocumentCaptureHiddenInstructions = {
   render: (args) => `
-        <document-capture-screens hide-instructions theme-color='${args['theme-color']}'>
+        <document-capture-screens hide-instructions theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </document-capture-screens>
     `,
 };
 
 export const DocumentCaptureHideBackOfId = {
   render: (args) => `
-        <document-capture-screens hide-back-of-id theme-color='${args['theme-color']}'>
+        <document-capture-screens hide-back-of-id theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </document-capture-screens>
     `,
 };
 
 export const DocumentCaptureAllowAttributes = {
   render: (args) => `
-        <document-capture-screens document-capture-screens-modes='camera,upload' theme-color='${args['theme-color']}'>
+        <document-capture-screens document-capture-screens-modes='camera,upload' theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </document-capture-screens>
     `,
 };
 
 export const DocumentCaptureHideInstructionNBackOfId = {
   render: (args) => `
-        <document-capture-screens hide-back-of-id hide-instructions theme-color='${args['theme-color']}'>
+        <document-capture-screens hide-back-of-id hide-instructions theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </document-capture-screens>
     `,
 };

--- a/packages/web-components/components/selfie/src/SelfieCaptureScreens.stories.js
+++ b/packages/web-components/components/selfie/src/SelfieCaptureScreens.stories.js
@@ -1,7 +1,12 @@
 import './SelfieCaptureScreens';
 
 const meta = {
+  args: {
+    'hide-attribution': false,
+    'theme-color': '#001096',
+  },
   argTypes: {
+    'hide-attribution': { control: 'boolean' },
     'theme-color': { control: 'color' },
   },
   component: 'selfie-capture-screens',
@@ -10,21 +15,15 @@ const meta = {
 export default meta;
 
 export const SelfieCaptureFlow = {
-  args: {
-    'theme-color': '#001096',
-  },
   render: (args) => `
-        <selfie-capture-screens theme-color='${args['theme-color']}'>
+        <selfie-capture-screens theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </selfie-capture-screens>
     `,
 };
 
 export const SelfieCaptureFlowHiddenInstructions = {
-  args: {
-    'theme-color': '#001096',
-  },
   render: (args) => `
-        <selfie-capture-screens hide-instructions theme-color='${args['theme-color']}'>
+        <selfie-capture-screens hide-instructions theme-color='${args['theme-color']}' ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </selfie-capture-screens>
     `,
 };

--- a/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.stories.js
+++ b/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.stories.js
@@ -2,9 +2,11 @@ import './SmartCameraWeb';
 
 const meta = {
   args: {
+    'hide-attribution': false,
     'theme-color': '#001096',
   },
   argTypes: {
+    'hide-attribution': { control: 'boolean' },
     'theme-color': { control: 'color' },
   },
   component: 'smart-camera-web',
@@ -14,35 +16,35 @@ export default meta;
 
 export const SmartCameraWeb = {
   render: (args) => `
-        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation>
+        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </smart-camera-web>
     `,
 };
 
 export const SmartCameraWebWithOutInstructions = {
   render: (args) => `
-        <smart-camera-web theme-color='${args['theme-color']}' capture-id hide-instructions>
+        <smart-camera-web theme-color='${args['theme-color']}' capture-id hide-instructions ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </smart-camera-web>
     `,
 };
 
 export const SmartCameraWebWithOutNavigation = {
   render: (args) => `
-        <smart-camera-web theme-color='${args['theme-color']}' capture-id>
+        <smart-camera-web theme-color='${args['theme-color']}' capture-id ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </smart-camera-web>
     `,
 };
 
 export const SmartCameraWebWithOutBackToHost = {
   render: (args) => `
-        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation hide-back-to-host>
+        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation hide-back-to-host ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </smart-camera-web>
     `,
 };
 
 export const SmartCameraWebWithOutBackId = {
   render: (args) => `
-        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation hide-back-of-id>
+        <smart-camera-web theme-color='${args['theme-color']}' capture-id show-navigation hide-back-of-id ${args['hide-attribution'] ? 'hide-attribution' : ''}>
         </smart-camera-web>
     `,
 };

--- a/packages/web-components/cypress/e2e/smart-camera-web-attribution.cy.js
+++ b/packages/web-components/cypress/e2e/smart-camera-web-attribution.cy.js
@@ -1,5 +1,6 @@
 describe('SmartCameraWeb', () => {
   it('shows attribution by default', () => {
+    cy.clock();
     cy.visit('/smart-camera-web');
     cy.get('smart-camera-web')
       .shadow()
@@ -7,13 +8,240 @@ describe('SmartCameraWeb', () => {
       .shadow()
       .find('powered-by-smile-id')
       .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .find('#allow')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture')
+      .shadow()
+      .find('#start-image-capture')
+      .click();
+    cy.tick(8000);
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-review')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-review')
+      .shadow()
+      .find('#select-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-front')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-front')
+      .shadow()
+      .find('#take-photo')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .find('#capture-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#front-of-document-capture-review')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#front-of-document-capture-review')
+      .shadow()
+      .find('#select-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-back')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-back')
+      .shadow()
+      .find('#take-photo')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-back')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-back')
+      .shadow()
+      .find('#capture-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#back-of-document-capture-review')
+      .shadow()
+      .find('powered-by-smile-id')
+      .should('be.visible');
   });
 
   it.only('hides attribution when `hide-attribution` attribute is passed', () => {
+    cy.clock();
     cy.visit('/capture-back-of-id-hide-attribution');
     cy.get('smart-camera-web')
       .shadow()
       .find('selfie-capture-instructions')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .find('#allow')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture')
+      .shadow()
+      .find('#start-image-capture')
+      .click();
+    cy.tick(8000);
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-review')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-review')
+      .shadow()
+      .find('#select-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-front')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-front')
+      .shadow()
+      .find('#take-photo')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .find('#capture-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#front-of-document-capture-review')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#front-of-document-capture-review')
+      .shadow()
+      .find('#select-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-back')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-instructions#document-capture-instructions-back')
+      .shadow()
+      .find('#take-photo')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-back')
+      .shadow()
+      .get('powered-by-smile-id')
+      .should('not.exist');
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-back')
+      .shadow()
+      .find('#capture-id-image')
+      .click();
+
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('document-capture-review#back-of-document-capture-review')
       .shadow()
       .get('powered-by-smile-id')
       .should('not.exist');


### PR DESCRIPTION
This adds a fix for attribution not hidden on document capture screens even when the attribute `hide-attribution` is supplied through the  `smart-camera-web` tag.