### PR TITLE
[web-components] Hide cancel button and install fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Handle errors gracefully
+- Fixed document capture not hidden when `hide_attribution` is specified
+- Cancel button on the selfie capture instructions screen will now be hidden when back button is hidden
 
 ## [1.4.4] - 2024-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Handle errors gracefully
 - Fixed document capture not hidden when `hide_attribution` is specified
 - Cancel button on the selfie capture instructions screen will now be hidden when back button is hidden

--- a/package-lock.json
+++ b/package-lock.json
@@ -16865,7 +16865,7 @@
         "@sentry/browser": "^8.33.0",
         "@sentry/esbuild-plugin": "^2.22.3",
         "@smile_identity/smart-camera-web": "file:../smart-camera-web",
-        "@smileid/web-components": "^1.0.0",
+        "@smileid/web-components": "<2.0.0",
         "jszip": "^3.10.1",
         "validate.js": "^0.13.1"
       },
@@ -16885,6 +16885,15 @@
         "serve": "^14.2.3"
       }
     },
+    "packages/embed/node_modules/@smileid/web-components": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@smileid/web-components/-/web-components-1.4.4.tgz",
+      "integrity": "sha512-N2z39ykBmKNnGsdBO24rPrXfJYvKSzjGhu1HFIdV4dVJ0GkGu6IJ61FVcuxJQYV8B26VtKtnb45T0mSYM9HIuQ==",
+      "dependencies": {
+        "signature_pad": "^5.0.2",
+        "validate.js": "^0.13.1"
+      }
+    },
     "packages/smart-camera-web": {
       "name": "@smile_identity/smart-camera-web",
       "version": "1.4.4",
@@ -16902,7 +16911,7 @@
     },
     "packages/web-components": {
       "name": "@smileid/web-components",
-      "version": "1.4.4",
+      "version": "1.4.5-alpha.1",
       "dependencies": {
         "signature_pad": "^5.0.2",
         "validate.js": "^0.13.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16911,7 +16911,7 @@
     },
     "packages/web-components": {
       "name": "@smileid/web-components",
-      "version": "1.4.5-alpha.1",
+      "version": "1.4.4",
       "dependencies": {
         "signature_pad": "^5.0.2",
         "validate.js": "^0.13.1"

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -30,7 +30,7 @@
     "@sentry/browser": "^8.33.0",
     "@sentry/esbuild-plugin": "^2.22.3",
     "@smile_identity/smart-camera-web": "file:../smart-camera-web",
-    "@smileid/web-components": "^1.0.0",
+    "@smileid/web-components": "<2.0.0",
     "jszip": "^3.10.1",
     "validate.js": "^0.13.1"
   },

--- a/packages/web-components/components/document/src/DocumentCaptureScreens.js
+++ b/packages/web-components/components/document/src/DocumentCaptureScreens.js
@@ -5,7 +5,9 @@ import SmartCamera from '../../../domain/camera/src/SmartCamera';
 import './document-capture';
 import './document-capture-review';
 import './document-capture-instructions';
-import { version as COMPONENTS_VERSION } from '../../../package.json';
+import packageJson from '../../../package.json';
+
+const COMPONENTS_VERSION = packageJson.version;
 
 async function getPermissions(captureScreen) {
   try {

--- a/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
+++ b/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
@@ -3,7 +3,9 @@ import './selfie-capture-instructions';
 import './selfie-capture-review';
 import SmartCamera from '../../../domain/camera/src/SmartCamera';
 import styles from '../../../styles/src/styles';
-import { version as COMPONENTS_VERSION } from '../../../package.json';
+import packageJson from '../../../package.json';
+
+const COMPONENTS_VERSION = packageJson.version;
 
 async function getPermissions(captureScreen, facingMode = 'user') {
   try {

--- a/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
+++ b/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
@@ -543,7 +543,7 @@ function templateString() {
         <button id='allow' data-variant='solid full-width' class='button theme-background'>
             Allow
         </button>
-        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem' ${(this.hideBack || !this.showNavigation) ? 'hidden' : ''}>
+        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem' ${this.hideBack || !this.showNavigation ? 'hidden' : ''}>
             Cancel
         </button>
        </section>

--- a/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
+++ b/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
@@ -543,7 +543,7 @@ function templateString() {
         <button id='allow' data-variant='solid full-width' class='button theme-background'>
             Allow
         </button>
-        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem' ${this.hideBack ? 'hidden' : ''}>
+        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem' ${(this.hideBack || !this.showNavigation) ? 'hidden' : ''}>
             Cancel
         </button>
        </section>

--- a/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
+++ b/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
@@ -305,7 +305,7 @@ function templateString() {
     </style>
     ${styles(this.themeColor)}
     <div id="selfie-capture-instruction-screen" class="flow center">
-    <smileid-navigation theme-color=${this.themeColor} ${this.showNavigation ? 'show-navigation' : ''} ${this.hideBack ? 'hide-back' : ''}></smileid-navigation>
+    <smileid-navigation theme-color=${this.themeColor} ${this.hideBack ? 'hide-back' : ''} ${this.showNavigation ? '' : 'hidden'}></smileid-navigation>
     <header>
       <svg xmlns="http://www.w3.org/2000/svg" width="65" height="91" viewBox="0 0 65 91" fill="none">
       <g clip-path="url(#clip0_604_692)">
@@ -543,7 +543,7 @@ function templateString() {
         <button id='allow' data-variant='solid full-width' class='button theme-background'>
             Allow
         </button>
-        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem'>
+        <button id='cancel' data-variant='outline full-width' class="button" style='--flow-space: 1.5rem' ${this.hideBack ? 'hidden' : ''}>
             Cancel
         </button>
        </section>
@@ -628,6 +628,12 @@ class SelfieCaptureInstructions extends HTMLElement {
 
   handleCloseEvents() {
     this.dispatchEvent(new CustomEvent('selfie-capture-instructions.close'));
+  }
+
+  static get observedAttributes() {
+    return [
+      'show-navigation',
+    ];
   }
 }
 

--- a/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
+++ b/packages/web-components/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
@@ -631,9 +631,7 @@ class SelfieCaptureInstructions extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return [
-      'show-navigation',
-    ];
+    return ['show-navigation'];
   }
 }
 

--- a/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
+++ b/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
@@ -4,8 +4,9 @@ import SmartCamera from '../../../domain/camera/src/SmartCamera';
 import '../../document/src';
 import '../../selfie/src';
 import '../../camera-permission/CameraPermission';
+import packageJson from '../../../package.json';
 
-import { version as COMPONENTS_VERSION } from '../../../package.json';
+const COMPONENTS_VERSION = packageJson.version;
 
 function scwTemplateString() {
   return `

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@smileid/web-components",
-  "version": "1.4.5-alpha.1",
+  "version": "1.4.4",
+  "private": "true",
   "main": "index.js",
   "exports": {
     ".": "./index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smileid/web-components",
-  "version": "1.4.4",
-  "private": "true",
+  "version": "1.4.5-alpha.1",
+  "main": "index.js",
   "exports": {
     ".": "./index.js",
     "./combobox": "./components/combobox/src/index.js",


### PR DESCRIPTION
Fix default export error when only default export is available
Hide cancel button when back to host is added

Publish a beta version
Import into a nextjs project
Verify it imports correctly without issue

Verify that when `selfie-capture-screens` has attribute `hide-back-to-host` the cancel button is hidden on the selfie instruction page is hidden