### PR TITLE
[Embed][WebComponent] Support both hide back and hide back to host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.6] - 2024-12-19
+## [1.4.7] - 2024-12-23
+
+### Added
+
+- Added support for both `hide-back-to-host` and `hide-back` to web components (selfie capture instructions and smart camera web)
 
 ## Changed
+
+- Change embed to use the latest web components via file dependency
+- Added support for both `hide-back-to-host` and `hide-back` to web components (selfie capture instructions and smart camera web)
+
+## [1.4.6] - 2024-12-19
+
+### Changed
 
 - Fixed selfie import
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "example",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example",
-      "version": "1.4.4",
+      "version": "1.4.6",
       "dependencies": {
-        "@smileid/web-components": "file:../packages/web-components",
         "cors": "^2.8.5",
         "express": "^4.21.1",
         "smile-identity-core": "^3.1.0",
@@ -21,20 +20,21 @@
     },
     "../packages/web-components": {
       "name": "@smileid/web-components",
-      "version": "1.4.4",
+      "version": "1.4.6",
+      "extraneous": true,
       "dependencies": {
         "signature_pad": "^5.0.2",
         "validate.js": "^0.13.1"
       },
       "devDependencies": {
         "cypress": "^13.15.0",
-        "esbuild": "^0.21.5",
+        "esbuild": "^0.24.0",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-cypress": "^3.3.0",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-jest": "^28.6.0",
+        "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3"
       }
@@ -614,10 +614,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@smileid/web-components": {
-      "resolved": "../packages/web-components",
-      "link": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example",
   "private": true,
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "main": "server.js",
   "scripts": {

--- a/example/script.js
+++ b/example/script.js
@@ -65,43 +65,44 @@ export default function setupForm() {
         signature,
         timestamp,
       } = tokenResults;
-
-      if (window.SmileIdentity) {
-        window.SmileIdentity({
-          token,
-          product,
-          callback_url,
-          environment,
-          use_new_component: true,
-          //demo_mode: true,
-          previewBVNMFA: true,
-          hide_attribution: true,
-          document_capture_modes: ['camera', 'upload'],
-          allow_agent_mode: true,
-          consent_required: {
-            NG: ['BVN'],
-          },
-          partner_details: {
-            partner_id,
-            signature,
-            timestamp,
-            name: 'Demo Account',
-            logo_url: 'https://via.placeholder.com/50/000000/FFFFFF?text=DA',
-            policy_url: 'https://smileidentity.com/privacy-privacy',
-            theme_color: '#96002d',
-          },
-          onSuccess: () => {
-            resetButton();
-          },
-          onClose: () => {
-            resetButton();
-          },
-          onError: () => {
-            resetButton();
-          },
-        });
-      }
+      window.SmileIdentity({
+        token,
+        product,
+        callback_url,
+        environment,
+        use_new_component: true,
+        //demo_mode: true,
+        previewBVNMFA: true,
+        hide_attribution: true,
+        document_capture_modes: ['camera', 'upload'],
+        allow_agent_mode: true,
+        // id_selection: {
+        //   NG: ['PASSPORT']
+        // },
+        // consent_required: {
+        //   NG: ['BVN'],
+        // },
+        partner_details: {
+          partner_id,
+          signature,
+          timestamp,
+          name: 'Demo Account',
+          logo_url: 'https://via.placeholder.com/50/000000/FFFFFF?text=DA',
+          policy_url: 'https://smileidentity.com/privacy-privacy',
+          theme_color: '#96002d',
+        },
+        onSuccess: () => {
+          resetButton();
+        },
+        onClose: () => {
+          resetButton();
+        },
+        onError: () => {
+          resetButton();
+        },
+      });
     } catch (error) {
+      console.error(error);
       resetButton();
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smileid/web",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smileid/web",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "workspaces": [
         "packages/web-components/*/*",
@@ -16860,12 +16860,12 @@
     },
     "packages/embed": {
       "name": "@smileid/embed",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "@sentry/browser": "^8.33.0",
         "@sentry/esbuild-plugin": "^2.22.3",
         "@smile_identity/smart-camera-web": "file:../smart-camera-web",
-        "@smileid/web-components": "<2.0.0",
+        "@smileid/web-components": "file:../web-components",
         "jszip": "^3.10.1",
         "validate.js": "^0.13.1"
       },
@@ -16885,18 +16885,9 @@
         "serve": "^14.2.3"
       }
     },
-    "packages/embed/node_modules/@smileid/web-components": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@smileid/web-components/-/web-components-1.4.4.tgz",
-      "integrity": "sha512-N2z39ykBmKNnGsdBO24rPrXfJYvKSzjGhu1HFIdV4dVJ0GkGu6IJ61FVcuxJQYV8B26VtKtnb45T0mSYM9HIuQ==",
-      "dependencies": {
-        "signature_pad": "^5.0.2",
-        "validate.js": "^0.13.1"
-      }
-    },
     "packages/smart-camera-web": {
       "name": "@smile_identity/smart-camera-web",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "devDependencies": {
         "@cypress/code-coverage": "^3.12.46",
@@ -16911,7 +16902,7 @@
     },
     "packages/web-components": {
       "name": "@smileid/web-components",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "signature_pad": "^5.0.2",
         "validate.js": "^0.13.1"
@@ -16931,7 +16922,7 @@
     },
     "packages/web-components/components/signature-pad": {
       "name": "@smileid/signature-pad",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "signature_pad": "^5.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "A collection of SmileID browser clients and components",
   "main": "index.js",
   "private": true,

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/embed",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Self Hosted Integration for Smile Identity on the Web",
   "private": true,
   "main": "inline.js",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -30,7 +30,7 @@
     "@sentry/browser": "^8.33.0",
     "@sentry/esbuild-plugin": "^2.22.3",
     "@smile_identity/smart-camera-web": "file:../smart-camera-web",
-    "@smileid/web-components": "<2.0.0",
+    "@smileid/web-components": "file:../web-components",
     "jszip": "^3.10.1",
     "validate.js": "^0.13.1"
   },

--- a/packages/smart-camera-web/package.json
+++ b/packages/smart-camera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smile_identity/smart-camera-web",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "WebComponent for smartly capturing images on the web, for use with SmileIdentity",
   "main": "smart-camera-web.js",
   "scripts": {

--- a/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
+++ b/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
@@ -194,7 +194,10 @@ class SelfieCaptureScreens extends HTMLElement {
   }
 
   get hideBack() {
-    return this.hasAttribute('hide-back-to-host') || this.hasAttribute('hide-back') ? 'hide-back' : '';
+    return this.hasAttribute('hide-back-to-host') ||
+      this.hasAttribute('hide-back')
+      ? 'hide-back'
+      : '';
   }
 
   get disableImageTests() {

--- a/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
+++ b/packages/web-components/components/selfie/src/SelfieCaptureScreens.js
@@ -194,7 +194,7 @@ class SelfieCaptureScreens extends HTMLElement {
   }
 
   get hideBack() {
-    return this.hasAttribute('hide-back-to-host') ? 'hide-back' : '';
+    return this.hasAttribute('hide-back-to-host') || this.hasAttribute('hide-back') ? 'hide-back' : '';
   }
 
   get disableImageTests() {

--- a/packages/web-components/components/signature-pad/package.json
+++ b/packages/web-components/components/signature-pad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/signature-pad",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": "true",
   "exports": {
     ".": "./index.js"

--- a/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
+++ b/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
@@ -224,7 +224,7 @@ class SmartCameraWeb extends HTMLElement {
   }
 
   get hideBackToHost() {
-    return this.hasAttribute('hide-back-to-host') ? 'hide-back-to-host' : '';
+    return this.hasAttribute('hide-back-to-host') || this.hasAttribute('hide-back') ? 'hide-back' : '';
   }
 
   get allowAgentMode() {

--- a/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
+++ b/packages/web-components/components/smart-camera-web/src/SmartCameraWeb.js
@@ -224,7 +224,10 @@ class SmartCameraWeb extends HTMLElement {
   }
 
   get hideBackToHost() {
-    return this.hasAttribute('hide-back-to-host') || this.hasAttribute('hide-back') ? 'hide-back' : '';
+    return this.hasAttribute('hide-back-to-host') ||
+      this.hasAttribute('hide-back')
+      ? 'hide-back'
+      : '';
   }
 
   get allowAgentMode() {

--- a/packages/web-components/cypress/e2e/smart-camera-web-hide-back-to-host.cy.js
+++ b/packages/web-components/cypress/e2e/smart-camera-web-hide-back-to-host.cy.js
@@ -31,31 +31,31 @@ describe('SmartCameraWeb', () => {
 
   it('hides back exit and cancel button when `hide-back-to-host` attribute is passed', () => {
     cy.get('smart-camera-web')
-    .invoke('attr', 'hide-back-to-host', 'true')
-    .should('have.attr', 'hide-back-to-host', 'true');
+      .invoke('attr', 'hide-back-to-host', 'true')
+      .should('have.attr', 'hide-back-to-host', 'true');
 
     cy.get('smart-camera-web')
-    .shadow()
-    .find('selfie-capture-instructions')
-    .should('be.visible');
-  cy.get('smart-camera-web')
-    .shadow()
-    .find('selfie-capture-instructions')
-    .shadow()
-    .should('contain.text', "Next, we'll take a quick selfie");
-  cy.get('smart-camera-web')
-    .shadow()
-    .find('selfie-capture-instructions')
-    .shadow()
-    .find('smileid-navigation')
-    .shadow()
-    .get('.back-button')
-    .should('not.exist');
-  cy.get('smart-camera-web')
-    .shadow()
-    .find('selfie-capture-instructions')
-    .shadow()
-    .get('#cancel')
-    .should('not.exist');
+      .shadow()
+      .find('selfie-capture-instructions')
+      .should('be.visible');
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .should('contain.text', "Next, we'll take a quick selfie");
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .find('smileid-navigation')
+      .shadow()
+      .get('.back-button')
+      .should('not.exist');
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .get('#cancel')
+      .should('not.exist');
   });
 });

--- a/packages/web-components/cypress/e2e/smart-camera-web-hide-back-to-host.cy.js
+++ b/packages/web-components/cypress/e2e/smart-camera-web-hide-back-to-host.cy.js
@@ -1,0 +1,61 @@
+describe('SmartCameraWeb', () => {
+  beforeEach(() => {
+    cy.visit('/capture-back-of-id-navigation');
+  });
+
+  it('shows attribution by default', () => {
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .should('be.visible');
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .should('contain.text', "Next, we'll take a quick selfie");
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .find('smileid-navigation')
+      .shadow()
+      .find('.back-button')
+      .should('be.visible');
+    cy.get('smart-camera-web')
+      .shadow()
+      .find('selfie-capture-instructions')
+      .shadow()
+      .find('#cancel')
+      .should('be.visible');
+  });
+
+  it('hides back exit and cancel button when `hide-back-to-host` attribute is passed', () => {
+    cy.get('smart-camera-web')
+    .invoke('attr', 'hide-back-to-host', 'true')
+    .should('have.attr', 'hide-back-to-host', 'true');
+
+    cy.get('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .should('be.visible');
+  cy.get('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .shadow()
+    .should('contain.text', "Next, we'll take a quick selfie");
+  cy.get('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .shadow()
+    .find('smileid-navigation')
+    .shadow()
+    .get('.back-button')
+    .should('not.exist');
+  cy.get('smart-camera-web')
+    .shadow()
+    .find('selfie-capture-instructions')
+    .shadow()
+    .get('#cancel')
+    .should('not.exist');
+  });
+});

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web-components",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": "true",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
This updates the embed to use the latest web components via file dependency 
Also updates the example up to the latest web components version
Added support for both `hide-back-to-host` and `hide-back` to web components (selfie capture instructions and smart camera web)

## Testing

The test should pass

Update  the example app, add only one id to `id_selection` option
Run the example app
The cancel button and the back button on the selfie instruction page should be hidden