### PR TITLE
Play video after metadata loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix abort error when access biometric kyc page
+
 ## [1.4.7] - 2024-12-23
 
 ### Added

--- a/packages/smart-camera-web/smart-camera-web.js
+++ b/packages/smart-camera-web/smart-camera-web.js
@@ -1637,7 +1637,9 @@ class SmartCameraWeb extends HTMLElement {
     } else {
       video.src = window.URL.createObjectURL(stream);
     }
-    video.play();
+    video.onloadedmetadata = () => {
+      video.play();
+    };
 
     if (!videoExists) this.videoContainer.prepend(video);
 
@@ -1675,7 +1677,6 @@ class SmartCameraWeb extends HTMLElement {
     } else {
       video.src = window.URL.createObjectURL(stream);
     }
-    video.play();
 
     const videoContainer =
       this.activeScreen === this.IDCameraScreen
@@ -1683,6 +1684,7 @@ class SmartCameraWeb extends HTMLElement {
         : this.backOfIDCameraScreen.querySelector('.id-video-container');
 
     video.onloadedmetadata = () => {
+      video.play();
       videoContainer.querySelector('.actions').hidden = false;
     };
 


### PR DESCRIPTION
Fixes the [video abort error](https://smile-identity.sentry.io/issues/5544304192/?project=4507143981236224&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=0) when displaying the capture screen for biometric kyc.