### PR TITLE
feat: increase selfie capture head size

### DIFF
--- a/packages/web-components/src/components/selfie/src/selfie-capture-review/SelfieCaptureReview.js
+++ b/packages/web-components/src/components/selfie/src/selfie-capture-review/SelfieCaptureReview.js
@@ -126,13 +126,6 @@ function templateString() {
         z-index: 1;
         block-size: 100%;
       }
-    
-      .selfie-container,
-      .selfie-review-container.landscape {
-        height: auto;
-        clip-path: inset(15% 20% 20% 20% round 10px);
-        overflow: hidden;
-      }
 
       .selfie-container img {
         background-color: black;

--- a/packages/web-components/src/components/selfie/src/selfie-capture/SelfieCapture.js
+++ b/packages/web-components/src/components/selfie/src/selfie-capture/SelfieCapture.js
@@ -358,7 +358,7 @@ function templateString() {
     left: 50%;
     min-width: auto;
     position: absolute;
-    top: calc(50% - 3px);
+    top: 50%;
     transform: translateX(-50%) translateY(50%);
   }
 
@@ -381,7 +381,7 @@ function templateString() {
   }
 
   .video-container video {
-    min-height: 100%;
+    height: 150%;
     transform: scaleX(-1) translateX(50%) translateY(-50%);
   }
 
@@ -520,7 +520,7 @@ function templateString() {
       <div class='video-container'>
         <div class='video'>
         </div>
-        <svg id="image-outline" width="215" height="245" viewBox="0 0 215 245" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg id="image-outline" width="215" height="245" viewBox="0 0 215 245" fill="none" xmlns="http://www.w3.org/2000/svg" style="position: relative;">
           <path d="M210.981 122.838C210.981 188.699 164.248 241.268 107.55 241.268C50.853 241.268 4.12018 188.699 4.12018 122.838C4.12018 56.9763 50.853 4.40771 107.55 4.40771C164.248 4.40771 210.981 56.9763 210.981 122.838Z" stroke="${this.themeColor}" stroke-width="7.13965"/>
         </svg>
         <div id="smile-cta-box">


### PR DESCRIPTION
Increase head (oval) size relative to the video. Increase size of selfie preview. Show only cropped selfie in preview, not CSS-clipped version of full selfie image.