### PR TITLE
fix embed url in preview app

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,6 +88,7 @@ jobs:
       - name: set sst stage
         id: get_branch_name
         run: |
+          echo "DEST_DIR_EMBED=inline/preview-$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
           BRANCH_NAME=${{ github.event.pull_request.head.ref }}
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._]/-/g')
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> "$GITHUB_OUTPUT"
@@ -100,7 +101,8 @@ jobs:
           npm run sst secret set PartnerId ${{ secrets.PREVIEW_PARTNER_ID }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set CallbackUrl ${{ secrets.PREVIEW_CALLBACK_URL }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set SmileIdApiKey ${{ secrets.PREVIEW_SMILEID_API_KEY }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
-          npm run sst secret set SmileIdEnvironment ${{ secrets.PREVIEW_SMILEID_ENVIRONMENT }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
+          npm run sst secret set SmileIdEnvironment ${{ secrets.PREVIEW_SMILEID_ENVIRONMENT }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
+          npm run sst secret set EmbedUrl ${{ steps.get_branch_name.outcome.DEST_DIR_EMBED }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
       - name: deploy sst app
         if: github.event.pull_request.merged != true
         id: deploy_sst_app

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -102,7 +102,7 @@ jobs:
           npm run sst secret set CallbackUrl ${{ secrets.PREVIEW_CALLBACK_URL }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set SmileIdApiKey ${{ secrets.PREVIEW_SMILEID_API_KEY }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set SmileIdEnvironment ${{ secrets.PREVIEW_SMILEID_ENVIRONMENT }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
-          npm run sst secret set EmbedUrl ${{ steps.get_branch_name.outcome.DEST_DIR_EMBED }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
+          npm run sst secret set EmbedUrl ${{ steps.get_branch_name.outputs.DEST_DIR_EMBED }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
       - name: deploy sst app
         if: github.event.pull_request.merged != true
         id: deploy_sst_app

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -102,7 +102,7 @@ jobs:
           npm run sst secret set CallbackUrl ${{ secrets.PREVIEW_CALLBACK_URL }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set SmileIdApiKey ${{ secrets.PREVIEW_SMILEID_API_KEY }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
           npm run sst secret set SmileIdEnvironment ${{ secrets.PREVIEW_SMILEID_ENVIRONMENT }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }} &&
-          npm run sst secret set EmbedUrl ${{ steps.get_branch_name.outputs.DEST_DIR_EMBED }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
+          npm run sst secret set EmbedUrl ${{ env.DEST_DIR_EMBED }} -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
       - name: deploy sst app
         if: github.event.pull_request.merged != true
         id: deploy_sst_app

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -171,8 +171,8 @@ export default function Product() {
           </form>
 
           <script
-            src={`https://cdn.smileidentity.com/inline/${
-              appStage === 'main' ? 'v2' : embedUrl
+            src={`https://cdn.smileidentity.com/${
+              appStage === 'main' ? 'inline/v2' : embedUrl
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -170,7 +170,7 @@ export default function Product() {
 
           <script
             src={`https://cdn.smileidentity.com/inline/${
-              appStage === 'main' ? 'v2' : `preview-${appStage}`
+              appStage === 'main' ? 'v2' : `${process.env.EmbedUrl || 'preview-'+appStage}`
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -172,7 +172,7 @@ export default function Product() {
             src={`https://cdn.smileidentity.com/inline/${
               appStage === 'main'
                 ? 'v2'
-                : `${process.env.EmbedUrl || 'preview-' + appStage}`
+                : `${Resource.EmbedUrl.value || 'preview-' + appStage}`
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -170,7 +170,9 @@ export default function Product() {
 
           <script
             src={`https://cdn.smileidentity.com/inline/${
-              appStage === 'main' ? 'v2' : (process.env.EmbedUrl || 'preview-'+appStage)
+              appStage === 'main'
+                ? 'v2'
+                : `${process.env.EmbedUrl || 'preview-' + appStage}`
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -64,17 +64,19 @@ export async function loader({ params }: LoaderFunctionArgs) {
       product,
       apiUrl: Resource.GetToken.url,
       appStage: Resource.App.stage,
+      embedUrl: Resource.EmbedUrl.value || `preview-${Resource.App.stage}`,
     };
   }
-  return null;
+  return {};
 }
 
 export default function Product() {
-  const { product, apiUrl, appStage } = useLoaderData<{
-    product: Product;
-    apiUrl: string;
-    appStage: string;
-  } | null>(null);
+  const { product, apiUrl, appStage, embedUrl } = useLoaderData<{
+    product?: Product;
+    apiUrl?: string;
+    appStage?: string;
+    embedUrl?: string;
+  }>();
   const [isGettingToken, setIsGettingToken] = useState<boolean>(false);
 
   function initializeSdk(config: TokenResults) {
@@ -170,9 +172,7 @@ export default function Product() {
 
           <script
             src={`https://cdn.smileidentity.com/inline/${
-              appStage === 'main'
-                ? 'v2'
-                : `${Resource.EmbedUrl.value || 'preview-' + appStage}`
+              appStage === 'main' ? 'v2' : embedUrl
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/app/routes/products.$productName.tsx
+++ b/previews/app/routes/products.$productName.tsx
@@ -170,7 +170,7 @@ export default function Product() {
 
           <script
             src={`https://cdn.smileidentity.com/inline/${
-              appStage === 'main' ? 'v2' : `${process.env.EmbedUrl || 'preview-'+appStage}`
+              appStage === 'main' ? 'v2' : (process.env.EmbedUrl || 'preview-'+appStage)
             }/js/script.min.js`}
           ></script>
         </>

--- a/previews/sst.config.ts
+++ b/previews/sst.config.ts
@@ -14,6 +14,7 @@ export default $config({
     const CALLBACK_URL = new sst.Secret('CallbackUrl');
     const SMILEID_API_KEY = new sst.Secret('SmileIdApiKey');
     const SMILE_ID_ENVIRONMENT = new sst.Secret('SmileIdEnvironment');
+    const EmbedUrl = new sst.Secret('EmbedUrl');
 
     const api = new sst.aws.Function('GetToken', {
       handler: 'api/lambda.handler',
@@ -22,7 +23,7 @@ export default $config({
     });
 
     const site = new sst.aws.Remix('PreviewApp', {
-      link: [api],
+      link: [api, EmbedUrl],
     });
 
     return {


### PR DESCRIPTION
### **User description**
When a branch has `/` in the name. The preview app fails to get the right embed url.

### Test
The preview app should be able to progress with verifications


___

### **PR Type**
Bug fix


___

### **Description**
- Fix embed URL handling in preview app

- Support branch names with slashes

- Add EmbedUrl secret for configuration

- Update GitHub workflow to set embed URL


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>products.$productName.tsx</strong><dd><code>Update embed script URL to use environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

previews/app/routes/products.$productName.tsx

<li>Modified script source URL to use <code>process.env.EmbedUrl</code> if available, <br>falling back to the previous <code>preview-${appStage}</code> pattern


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/427/files#diff-fb6741a60e16f847f45735c3acaeaded297135cc37d29d9b56ea0f9132df387c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sst.config.ts</strong><dd><code>Add EmbedUrl secret configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

previews/sst.config.ts

<li>Added new <code>EmbedUrl</code> secret<br> <li> Linked the <code>EmbedUrl</code> secret to the Remix app configuration


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/427/files#diff-daaf5ffe465be5314b6a67701b39dafdacfc7fd167a3442734b27e2cd596d68d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deploy-preview.yml</strong><dd><code>Update workflow to set EmbedUrl secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-preview.yml

<li>Added <code>DEST_DIR_EMBED</code> environment variable for the embed URL path<br> <li> Added configuration to set the <code>EmbedUrl</code> secret with the proper path <br>format


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/427/files#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>