### PR TITLE
ci: build web-components before building embed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,11 @@ jobs:
         uses: actions/checkout@v4
       - name: set node version
         uses: actions/setup-node@v4
+      - name: build web-components dependency
+        run: |
+          cd ../web-components
+          npm ci
+          npm run build
       - name: install dependencies
         run: npm ci
       - name: get-npm-version


### PR DESCRIPTION
Just like the deploy-preview, we build web-components before building embed.