### PR TITLE
Remove web component padding

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -179,8 +179,3 @@ jobs:
             ✅ Preview URL for Web Client:
 
             ${{ steps.get_app_url.outputs.PREVIEW_APP_URL }}
-            https://cdn.smileidentity.com/${{ env.DEST_DIR_EMBED }}/js/script.min.js
-
-            ✅ Preview URL for Web Client:
-
-            ${{ steps.get_app_url.outputs.PREVIEW_APP_URL }}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example",
-  "version": "2.0.2",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example",
-      "version": "2.0.2",
+      "version": "10.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@smileid/web-components": "file:../packages/web-components",
@@ -23,23 +23,28 @@
     },
     "../packages/web-components": {
       "name": "@smileid/web-components",
-      "version": "2.0.2",
+      "version": "10.0.0",
       "dependencies": {
         "@mediapipe/tasks-vision": "^0.10.22-rc.20250304",
         "@preact/signals": "^2.1.1",
+        "@tabler/icons-preact": "^3.34.0",
+        "preact": "^10.26.9",
         "preact-custom-element": "^4.3.0",
+        "preact-router": "^4.1.2",
         "signature_pad": "^5.0.2",
         "validate.js": "^0.13.1"
       },
       "devDependencies": {
-        "@preact/preset-vite": "^2.8.2",
+        "@preact/preset-vite": "^2.10.2",
         "@types/node": "^20.11.24",
-        "@typescript-eslint/eslint-plugin": "^7.1.1",
-        "@typescript-eslint/parser": "^7.1.1",
+        "@types/preact-custom-element": "^4.0.4",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "cross-env": "^7.0.3",
         "cypress": "^13.15.0",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-cypress": "^3.3.0",
@@ -47,11 +52,11 @@
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-prettier": "^5.2.1",
         "glob": "^10.3.10",
-        "preact": "^10.19.6",
-        "prettier": "^3.3.3",
-        "typescript": "^5.4.2",
-        "vite": "^5.1.6",
-        "vite-plugin-dts": "^3.7.3",
+        "prettier": "^3.6.2",
+        "rollup-plugin-visualizer": "^6.0.3",
+        "typescript": "^5.8.3",
+        "vite": "^7.0.1",
+        "vite-plugin-dts": "^4.5.4",
         "vite-plugin-tsconfig-paths": "^1.4.1"
       }
     },

--- a/packages/web-components/lib/components/camera-permission/CameraPermission.js
+++ b/packages/web-components/lib/components/camera-permission/CameraPermission.js
@@ -8,7 +8,6 @@ function templateString() {
     ${styles(this.themeColor)}
     <style>
         .camera-permission-screen {
-          padding-block: 2rem;
           display: flex;
           flex-direction: column;
           max-block-size: 100%;

--- a/packages/web-components/lib/components/document/src/document-capture-review/DocumentCaptureReview.js
+++ b/packages/web-components/lib/components/document/src/document-capture-review/DocumentCaptureReview.js
@@ -126,7 +126,6 @@ function templateString() {
     
     #document-capture-review-screen {
       block-size: 45rem;
-      padding-block: 2rem;
       display: flex;
       flex-direction: column;
       max-block-size: 100%;

--- a/packages/web-components/lib/components/document/src/document-capture/DocumentCapture.js
+++ b/packages/web-components/lib/components/document/src/document-capture/DocumentCapture.js
@@ -61,7 +61,6 @@ function templateString() {
       #document-capture-screen,
       #back-of-document-capture-screen {
         block-size: 45rem;
-        padding-block: 2rem;
         display: flex;
         flex-direction: column;
         max-block-size: 100%;

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-instructions/SelfieCaptureInstructions.js
@@ -260,7 +260,6 @@ function templateString() {
       }
 
       #selfie-capture-instruction-screen {
-        padding-block: 2rem;
         display: flex;
         flex-direction: column;
         max-block-size: 100%;

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-review/SelfieCaptureReview.js
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-review/SelfieCaptureReview.js
@@ -94,7 +94,6 @@ function templateString() {
       }
       #selfie-capture-review-screen {
         block-size: 45rem;
-        padding-block: 2rem;
         display: flex;
         flex-direction: column;
         max-block-size: 100%;

--- a/packages/web-components/lib/components/selfie/src/selfie-capture/SelfieCapture.js
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture/SelfieCapture.js
@@ -468,7 +468,6 @@ function templateString() {
   #selfie-capture-screen,
   #back-of-id-entry-screen {
     block-size: 45rem;
-    padding-block: 2rem;
     display: flex;
     flex-direction: column;
     max-block-size: 100%;

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
@@ -196,7 +196,6 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
           font-family: sans-serif;
           max-width: 356px;
           margin: 0 auto;
-          padding-block: 2rem;
         }
       `}</style>
     </div>

--- a/packages/web-components/lib/styles/src/styles.js
+++ b/packages/web-components/lib/styles/src/styles.js
@@ -260,7 +260,6 @@ ${typography}
 
   #document-capture-instructions-screen,
   #back-of-document-capture-instructions-screen {
-    padding-block: 2rem;
     display: flex;
     flex-direction: column;
     max-block-size: 100%;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Remove `padding-block: 2rem` from web component screens
• Clean up duplicate deployment preview URL comments
• Standardize layout spacing across capture components
• Improve visual consistency in component styling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>CameraPermission.js</strong><dd><code>Remove padding from camera permission screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-b10d3d9817c2956a2966340cb79d64506c5630cdc13bec35fee1897404dc30a6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentCaptureReview.js</strong><dd><code>Remove padding from document capture review screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-61d1b8cf6f0ea60cf1fd3ab37c4a75f9b0bae214ebfbeab81bbe1c1dc1ed0bbf">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentCapture.js</strong><dd><code>Remove padding from document capture screens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-c4d355c6f0a1ac8be4e8ddd3d16bab9f38a5fdde84d217bcb3c76a0b07b773f2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SelfieCaptureInstructions.js</strong><dd><code>Remove padding from selfie instruction screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-c45175889b83f09e539a6ac2a1236d8a2f9f9333fb1d776415dbf4234fdf66f2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SelfieCaptureReview.js</strong><dd><code>Remove padding from selfie review screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-65fb56171e504dd8d19ada47ac75b4b59a720da7bf764570227a0ca44c852ed1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SelfieCapture.js</strong><dd><code>Remove padding from selfie capture screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-c9e2fd6f4bb5d5b48f730297ff4d0c6b49984a57b45807bc70ac8c7e0dfdbe4d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles.js</strong><dd><code>Remove padding from document instruction screens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-ac2f0f7d602da8eedc6fd1b72c3ba25b484eedc4c9f9b53bc2e24e400f9e2f98">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SmartSelfieCapture.tsx</strong><dd><code>Remove padding from smart selfie capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-98051a6d928387bdb1bc98f6a9d8845367aeb69b289e1d730824269c3b446f9f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>deploy-preview.yml</strong><dd><code>Remove duplicate deployment preview URL comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/web-client/pull/449/files#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>