### PR TITLE
test: request payload signature headers

### DIFF
--- a/packages/embed/cypress/tests/document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/document-verification.cy.cjs
@@ -96,28 +96,37 @@ describe('document verification', () => {
       .find('document-capture-review#front-of-document-capture-review')
       .should('not.be.visible');
 
-    cy.wait('@getUploadURL')
-      .its('request.body')
-      .should((body) => {
-        const metadata = {};
-        body.metadata.forEach(({ name, value }) => {
-          metadata[name] = value;
-        });
-        expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
-        expect(metadata.document_front_image_origin).to.equal(
-          'camera_manual_capture',
-        );
-        expect(metadata.selfie_image_origin).to.equal('front_camera');
-        expect(metadata.active_liveness_type).to.equal('smile');
-        expect(metadata.active_liveness_version).to.equal('0.0.1');
-        expect(metadata.fingerprint).to.be.a('string');
-        expect(metadata.user_agent).to.be.a('string');
-        expect(metadata.document_front_capture_camera_name).to.be.a('string');
-        expect(metadata.camera_name).to.be.a('string');
-        expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(
-          0,
-        );
+    cy.wait('@getUploadURL').should((interception) => {
+      // Check request body
+      const body = interception.request.body;
+      const metadata = {};
+      body.metadata.forEach(({ name, value }) => {
+        metadata[name] = value;
       });
+      expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
+      expect(metadata.document_front_image_origin).to.equal(
+        'camera_manual_capture',
+      );
+      expect(metadata.selfie_image_origin).to.equal('front_camera');
+      expect(metadata.active_liveness_type).to.equal('smile');
+      expect(metadata.active_liveness_version).to.equal('0.0.1');
+      expect(metadata.fingerprint).to.be.a('string');
+      expect(metadata.user_agent).to.be.a('string');
+      expect(metadata.document_front_capture_camera_name).to.be.a('string');
+      expect(metadata.camera_name).to.be.a('string');
+      expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(0);
+
+      // Check request headers
+      const headers = interception.request.headers;
+      expect(headers).to.have.property('smileid-request-mac');
+      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers).to.have.property('smileid-request-timestamp');
+      expect(headers['smileid-request-timestamp']).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(headers).to.have.property('smileid-partner-id');
+      expect(headers['smileid-partner-id']).to.be.a('string');
+    });
 
     cy.wait('@successfulUpload');
 
@@ -237,24 +246,33 @@ describe('legacy support - preselected country / id_types', () => {
       .find('document-capture-review#front-of-document-capture-review')
       .should('not.be.visible');
 
-    cy.wait('@getUploadURL')
-      .its('request.body')
-      .should((body) => {
-        const metadata = {};
-        body.metadata.forEach(({ name, value }) => {
-          metadata[name] = value;
-        });
-        expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
-        expect(metadata.selfie_image_origin).to.equal('front_camera');
-        expect(metadata.active_liveness_type).to.equal('smile');
-        expect(metadata.active_liveness_version).to.equal('0.0.1');
-        expect(metadata.fingerprint).to.be.a('string');
-        expect(metadata.user_agent).to.be.a('string');
-        expect(metadata.camera_name).to.be.a('string');
-        expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(
-          0,
-        );
+    cy.wait('@getUploadURL').should((interception) => {
+      // Check request body
+      const body = interception.request.body;
+      const metadata = {};
+      body.metadata.forEach(({ name, value }) => {
+        metadata[name] = value;
       });
+      expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
+      expect(metadata.selfie_image_origin).to.equal('front_camera');
+      expect(metadata.active_liveness_type).to.equal('smile');
+      expect(metadata.active_liveness_version).to.equal('0.0.1');
+      expect(metadata.fingerprint).to.be.a('string');
+      expect(metadata.user_agent).to.be.a('string');
+      expect(metadata.camera_name).to.be.a('string');
+      expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(0);
+
+      // Check request headers
+      const headers = interception.request.headers;
+      expect(headers).to.have.property('smileid-request-mac');
+      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers).to.have.property('smileid-request-timestamp');
+      expect(headers['smileid-request-timestamp']).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(headers).to.have.property('smileid-partner-id');
+      expect(headers['smileid-partner-id']).to.be.a('string');
+    });
 
     cy.wait('@successfulUpload');
 

--- a/packages/embed/cypress/tests/document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/document-verification.cy.cjs
@@ -119,13 +119,17 @@ describe('document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers['smileid-request-mac'])
+        .to.be.a('string')
+        .and.not.be.empty();
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id']).to.be.a('string');
+      expect(headers['smileid-partner-id'])
+        .to.be.a('string')
+        .and.not.be.empty();
     });
 
     cy.wait('@successfulUpload');
@@ -265,13 +269,17 @@ describe('legacy support - preselected country / id_types', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers['smileid-request-mac'])
+        .to.be.a('string')
+        .and.not.be.empty();
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id']).to.be.a('string');
+      expect(headers['smileid-partner-id'])
+        .to.be.a('string')
+        .and.not.be.empty();
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/document-verification.cy.cjs
@@ -119,17 +119,13 @@ describe('document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-request-mac']).to.be.a('string');
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-partner-id']).to.be.a('string');
     });
 
     cy.wait('@successfulUpload');
@@ -269,17 +265,13 @@ describe('legacy support - preselected country / id_types', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-request-mac']).to.be.a('string');
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-partner-id']).to.be.a('string');
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
@@ -115,13 +115,17 @@ describe('enhanced document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers['smileid-request-mac'])
+        .to.be.a('string')
+        .and.not.be.empty();
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id']).to.be.a('string');
+      expect(headers['smileid-partner-id'])
+        .to.be.a('string')
+        .and.not.be.empty();
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
@@ -115,17 +115,13 @@ describe('enhanced document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-request-mac']).to.be.a('string');
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-partner-id']).to.be.a('string');
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
@@ -96,28 +96,37 @@ describe('enhanced document verification', () => {
       .find('document-capture-review#front-of-document-capture-review')
       .should('not.be.visible');
 
-    cy.wait('@getUploadURL')
-      .its('request.body')
-      .should((body) => {
-        const metadata = {};
-        body.metadata.forEach(({ name, value }) => {
-          metadata[name] = value;
-        });
-        expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
-        expect(metadata.document_front_image_origin).to.equal(
-          'camera_manual_capture',
-        );
-        expect(metadata.selfie_image_origin).to.equal('front_camera');
-        expect(metadata.active_liveness_type).to.equal('smile');
-        expect(metadata.active_liveness_version).to.equal('0.0.1');
-        expect(metadata.fingerprint).to.be.a('string');
-        expect(metadata.user_agent).to.be.a('string');
-        expect(metadata.document_front_capture_camera_name).to.be.a('string');
-        expect(metadata.camera_name).to.be.a('string');
-        expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(
-          0,
-        );
+    cy.wait('@getUploadURL').should((interception) => {
+      // Check request body
+      const body = interception.request.body;
+      const metadata = {};
+      body.metadata.forEach(({ name, value }) => {
+        metadata[name] = value;
       });
+      expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
+      expect(metadata.document_front_image_origin).to.equal(
+        'camera_manual_capture',
+      );
+      expect(metadata.selfie_image_origin).to.equal('front_camera');
+      expect(metadata.active_liveness_type).to.equal('smile');
+      expect(metadata.active_liveness_version).to.equal('0.0.1');
+      expect(metadata.fingerprint).to.be.a('string');
+      expect(metadata.user_agent).to.be.a('string');
+      expect(metadata.document_front_capture_camera_name).to.be.a('string');
+      expect(metadata.camera_name).to.be.a('string');
+      expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(0);
+
+      // Check request headers
+      const headers = interception.request.headers;
+      expect(headers).to.have.property('smileid-request-mac');
+      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers).to.have.property('smileid-request-timestamp');
+      expect(headers['smileid-request-timestamp']).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(headers).to.have.property('smileid-partner-id');
+      expect(headers['smileid-partner-id']).to.be.a('string');
+    });
 
     cy.wait('@successfulUpload');
 

--- a/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
@@ -119,17 +119,13 @@ describe('enhanced document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-request-mac']).to.be.a('string');
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-partner-id']).to.be.a('string');
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
@@ -119,13 +119,17 @@ describe('enhanced document verification', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers['smileid-request-mac'])
+        .to.be.a('string')
+        .and.not.be.empty();
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id']).to.be.a('string');
+      expect(headers['smileid-partner-id'])
+        .to.be.a('string')
+        .and.not.be.empty();
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/id-selection.cy.cjs
+++ b/packages/embed/cypress/tests/id-selection.cy.cjs
@@ -91,17 +91,13 @@ describe('No ID Selection', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-request-mac']).to.be.a('string');
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id'])
-        .to.be.a('string')
-        .and.not.be.empty();
+      expect(headers['smileid-partner-id']).to.be.a('string');
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/id-selection.cy.cjs
+++ b/packages/embed/cypress/tests/id-selection.cy.cjs
@@ -91,13 +91,17 @@ describe('No ID Selection', () => {
       // Check request headers
       const headers = interception.request.headers;
       expect(headers).to.have.property('smileid-request-mac');
-      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers['smileid-request-mac'])
+        .to.be.a('string')
+        .and.not.be.empty();
       expect(headers).to.have.property('smileid-request-timestamp');
       expect(headers['smileid-request-timestamp']).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
       expect(headers).to.have.property('smileid-partner-id');
-      expect(headers['smileid-partner-id']).to.be.a('string');
+      expect(headers['smileid-partner-id'])
+        .to.be.a('string')
+        .and.not.be.empty();
     });
 
     cy.wait('@successfulUpload');

--- a/packages/embed/cypress/tests/id-selection.cy.cjs
+++ b/packages/embed/cypress/tests/id-selection.cy.cjs
@@ -72,24 +72,33 @@ describe('No ID Selection', () => {
 
     cy.getIFrameBody().find('#submitForm').click();
 
-    cy.wait('@getUploadURL')
-      .its('request.body')
-      .should((body) => {
-        const metadata = {};
-        body.metadata.forEach(({ name, value }) => {
-          metadata[name] = value;
-        });
-        expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
-        expect(metadata.selfie_image_origin).to.equal('front_camera');
-        expect(metadata.active_liveness_type).to.equal('smile');
-        expect(metadata.active_liveness_version).to.equal('0.0.1');
-        expect(metadata.fingerprint).to.be.a('string');
-        expect(metadata.user_agent).to.be.a('string');
-        expect(metadata.camera_name).to.be.a('string');
-        expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(
-          0,
-        );
+    cy.wait('@getUploadURL').should((interception) => {
+      // Check request body
+      const body = interception.request.body;
+      const metadata = {};
+      body.metadata.forEach(({ name, value }) => {
+        metadata[name] = value;
       });
+      expect(metadata.browser_version).to.match(/^\d+(\.\d+)+$/);
+      expect(metadata.selfie_image_origin).to.equal('front_camera');
+      expect(metadata.active_liveness_type).to.equal('smile');
+      expect(metadata.active_liveness_version).to.equal('0.0.1');
+      expect(metadata.fingerprint).to.be.a('string');
+      expect(metadata.user_agent).to.be.a('string');
+      expect(metadata.camera_name).to.be.a('string');
+      expect(Number(metadata.selfie_capture_duration_ms)).to.be.greaterThan(0);
+
+      // Check request headers
+      const headers = interception.request.headers;
+      expect(headers).to.have.property('smileid-request-mac');
+      expect(headers['smileid-request-mac']).to.be.a('string');
+      expect(headers).to.have.property('smileid-request-timestamp');
+      expect(headers['smileid-request-timestamp']).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(headers).to.have.property('smileid-partner-id');
+      expect(headers['smileid-partner-id']).to.be.a('string');
+    });
 
     cy.wait('@successfulUpload');
 


### PR DESCRIPTION
### **User description**
Check request headers in tests.


___

### **PR Type**
Tests


___

### **Description**
- Add request header validation to Cypress tests

- Verify SmileID signature headers in upload requests

- Check MAC, timestamp, and partner ID headers

- Refactor test structure for better header access


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-verification.cy.cjs</strong><dd><code>Add header validation to document verification test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/document-verification.cy.cjs

<ul><li>Refactor test to access full interception object instead of just <br>request body<br> <li> Add validation for <code>smileid-request-mac</code>, <code>smileid-request-timestamp</code>, and <br><code>smileid-partner-id</code> headers<br> <li> Verify timestamp format matches ISO 8601 pattern<br> <li> Maintain existing request body metadata validation</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/476/files#diff-b457f1f37d8d1a933f526fe0849c1a88d244e499f6d7351f0a31c590036daa62">+56/-38</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification-dev.cy.cjs</strong><dd><code>Add header validation to enhanced document verification dev test</code></dd></summary>
<hr>

packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs

<ul><li>Refactor test to access full interception object instead of just <br>request body<br> <li> Add validation for SmileID signature headers (MAC, timestamp, partner <br>ID)<br> <li> Verify timestamp format matches ISO 8601 pattern<br> <li> Maintain existing request body metadata validation</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/476/files#diff-8a3ef0ddc7ad8a9ba4b9238a374a7a38d1386854fc13e33b0fd182cc1b3f64b8">+26/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification.cy.cjs</strong><dd><code>Add header validation to enhanced document verification test</code></dd></summary>
<hr>

packages/embed/cypress/tests/enhanced-document-verification.cy.cjs

<ul><li>Refactor test to access full interception object instead of just <br>request body<br> <li> Add validation for SmileID signature headers (MAC, timestamp, partner <br>ID)<br> <li> Verify timestamp format matches ISO 8601 pattern<br> <li> Maintain existing request body metadata validation</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/476/files#diff-75ff006a2d870eecdc90970589e2005869af5bec818f97e699b2c20343d7b57c">+30/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>id-selection.cy.cjs</strong><dd><code>Add header validation to ID selection test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/id-selection.cy.cjs

<ul><li>Refactor test to access full interception object instead of just <br>request body<br> <li> Add validation for SmileID signature headers (MAC, timestamp, partner <br>ID)<br> <li> Verify timestamp format matches ISO 8601 pattern<br> <li> Maintain existing request body metadata validation</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/476/files#diff-d60d36c2dc61c051dc6e10cc33bb125c03b363bd5781ed30393fe493b8846209">+26/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>