### PR TITLE
Incremental Smile Detection to improve hosted web detection pass rates

### DIFF
--- a/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
+++ b/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
@@ -16,11 +16,7 @@ const createLandmarks = (upperLipY = 0.55, lowerLipY = 0.58) => {
   return [points];
 };
 
-const installBrowserMocks = (
-  win,
-  mode = 'always-smile',
-  options = {},
-) => {
+const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
   const { switchAfterMs = 1600 } = options;
   const srcObjectStore = new WeakMap();
   const originalSrcObjectDescriptor = Object.getOwnPropertyDescriptor(
@@ -57,8 +53,7 @@ const installBrowserMocks = (
     return Promise.resolve();
   };
 
-  const originalDrawImage =
-    win.CanvasRenderingContext2D.prototype.drawImage;
+  const originalDrawImage = win.CanvasRenderingContext2D.prototype.drawImage;
   win.CanvasRenderingContext2D.prototype.drawImage = () => {};
 
   win.__restoreBrowserMocks = () => {
@@ -76,29 +71,29 @@ const installBrowserMocks = (
   Object.defineProperty(win.navigator, 'mediaDevices', {
     configurable: true,
     value: {
-    getUserMedia: (constraints = {}) => {
-      const requestedFacingMode = constraints?.video?.facingMode || 'user';
-      const track = {
-        stop: () => {},
-        getSettings: () => ({
-          facingMode: requestedFacingMode,
-          deviceId: 'fake-camera-device',
-        }),
-      };
+      getUserMedia: (constraints = {}) => {
+        const requestedFacingMode = constraints?.video?.facingMode || 'user';
+        const track = {
+          stop: () => {},
+          getSettings: () => ({
+            facingMode: requestedFacingMode,
+            deviceId: 'fake-camera-device',
+          }),
+        };
 
-      return Promise.resolve({
-        getTracks: () => [track],
-        getVideoTracks: () => [track],
-      });
-    },
-    enumerateDevices: () =>
-      Promise.resolve([
-        {
-          kind: 'videoinput',
-          deviceId: 'fake-camera-device',
-          label: 'Fake Camera',
-        },
-      ]),
+        return Promise.resolve({
+          getTracks: () => [track],
+          getVideoTracks: () => [track],
+        });
+      },
+      enumerateDevices: () =>
+        Promise.resolve([
+          {
+            kind: 'videoinput',
+            deviceId: 'fake-camera-device',
+            label: 'Fake Camera',
+          },
+        ]),
     },
   });
 
@@ -219,10 +214,15 @@ context('SmartSelfie Incremental Smile', () => {
   });
 
   it('keeps capture active when user is neutral first then progressively smiles', () => {
-    cy.visit('/?component=smartselfie-capture&direct=true&interval=350&duration=700', {
-      onBeforeLoad: (win) =>
-        installBrowserMocks(win, 'neutral-then-smile', { switchAfterMs: 500 }),
-    });
+    cy.visit(
+      '/?component=smartselfie-capture&direct=true&interval=350&duration=700',
+      {
+        onBeforeLoad: (win) =>
+          installBrowserMocks(win, 'neutral-then-smile', {
+            switchAfterMs: 500,
+          }),
+      },
+    );
 
     cy.get('smartselfie-capture')
       .shadow()

--- a/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
+++ b/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
@@ -71,14 +71,22 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
   Object.defineProperty(win.navigator, 'mediaDevices', {
     configurable: true,
     value: {
+      enumerateDevices: () =>
+        Promise.resolve([
+          {
+            deviceId: 'fake-camera-device',
+            kind: 'videoinput',
+            label: 'Fake Camera',
+          },
+        ]),
       getUserMedia: (constraints = {}) => {
         const requestedFacingMode = constraints?.video?.facingMode || 'user';
         const track = {
-          stop: () => {},
           getSettings: () => ({
-            facingMode: requestedFacingMode,
             deviceId: 'fake-camera-device',
+            facingMode: requestedFacingMode,
           }),
+          stop: () => {},
         };
 
         return Promise.resolve({
@@ -86,19 +94,10 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
           getVideoTracks: () => [track],
         });
       },
-      enumerateDevices: () =>
-        Promise.resolve([
-          {
-            kind: 'videoinput',
-            deviceId: 'fake-camera-device',
-            label: 'Fake Camera',
-          },
-        ]),
     },
   });
 
   const nonNeutralFrame = {
-    faceLandmarks: createLandmarks(0.55, 0.58),
     faceBlendshapes: [
       {
         categories: [
@@ -107,10 +106,10 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
         ],
       },
     ],
+    faceLandmarks: createLandmarks(0.55, 0.58),
   };
 
   const neutralFrame = {
-    faceLandmarks: createLandmarks(0.55, 0.565),
     faceBlendshapes: [
       {
         categories: [
@@ -119,6 +118,7 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
         ],
       },
     ],
+    faceLandmarks: createLandmarks(0.55, 0.565),
   };
 
   let progressiveFrameIndex = 0;
@@ -145,7 +145,6 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
     const mouthOpen = Math.min(mouthBase + progressiveFrameIndex * 0.015, 0.3);
 
     return {
-      faceLandmarks: createLandmarks(0.55, 0.55 + mouthOpen),
       faceBlendshapes: [
         {
           categories: [
@@ -154,6 +153,7 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
           ],
         },
       ],
+      faceLandmarks: createLandmarks(0.55, 0.55 + mouthOpen),
     };
   };
 
@@ -172,11 +172,11 @@ const installBrowserMocks = (win, mode = 'always-smile', options = {}) => {
   };
 
   win.__smileIdentityMediapipe = {
-    loaded: true,
-    loading: null,
     instance: {
       detectForVideo: () => getDetectionFrame(),
     },
+    loaded: true,
+    loading: null,
   };
 
   win.__selfiePublishEvents = 0;

--- a/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
+++ b/packages/web-components/cypress/e2e/smartselfie-incremental-smile.cy.js
@@ -1,0 +1,249 @@
+const createLandmarks = (upperLipY = 0.55, lowerLipY = 0.58) => {
+  const points = Array.from({ length: 15 }, () => ({
+    x: 0.5,
+    y: 0.6,
+    z: 0,
+  }));
+
+  points[0] = { x: 0.37, y: 0.42, z: 0 };
+  points[1] = { x: 0.63, y: 0.42, z: 0 };
+  points[2] = { x: 0.37, y: 0.78, z: 0 };
+  points[3] = { x: 0.63, y: 0.78, z: 0 };
+  points[4] = { x: 0.5, y: 0.6, z: 0 };
+  points[13] = { x: 0.5, y: upperLipY, z: 0 };
+  points[14] = { x: 0.5, y: lowerLipY, z: 0 };
+
+  return [points];
+};
+
+const installBrowserMocks = (
+  win,
+  mode = 'always-smile',
+  options = {},
+) => {
+  const { switchAfterMs = 1600 } = options;
+  const srcObjectStore = new WeakMap();
+  const originalSrcObjectDescriptor = Object.getOwnPropertyDescriptor(
+    win.HTMLMediaElement.prototype,
+    'srcObject',
+  );
+
+  Object.defineProperty(win.HTMLMediaElement.prototype, 'srcObject', {
+    configurable: true,
+    get() {
+      return srcObjectStore.get(this) || null;
+    },
+    set(value) {
+      srcObjectStore.set(this, value);
+    },
+  });
+
+  const originalPlay = win.HTMLMediaElement.prototype.play;
+  win.HTMLMediaElement.prototype.play = function play() {
+    Object.defineProperty(this, 'videoWidth', {
+      configurable: true,
+      get: () => 720,
+    });
+    Object.defineProperty(this, 'videoHeight', {
+      configurable: true,
+      get: () => 1280,
+    });
+    Object.defineProperty(this, 'readyState', {
+      configurable: true,
+      get: () => 3,
+    });
+
+    this.dispatchEvent(new win.Event('loadedmetadata'));
+    return Promise.resolve();
+  };
+
+  const originalDrawImage =
+    win.CanvasRenderingContext2D.prototype.drawImage;
+  win.CanvasRenderingContext2D.prototype.drawImage = () => {};
+
+  win.__restoreBrowserMocks = () => {
+    if (originalSrcObjectDescriptor) {
+      Object.defineProperty(
+        win.HTMLMediaElement.prototype,
+        'srcObject',
+        originalSrcObjectDescriptor,
+      );
+    }
+    win.HTMLMediaElement.prototype.play = originalPlay;
+    win.CanvasRenderingContext2D.prototype.drawImage = originalDrawImage;
+  };
+
+  Object.defineProperty(win.navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+    getUserMedia: (constraints = {}) => {
+      const requestedFacingMode = constraints?.video?.facingMode || 'user';
+      const track = {
+        stop: () => {},
+        getSettings: () => ({
+          facingMode: requestedFacingMode,
+          deviceId: 'fake-camera-device',
+        }),
+      };
+
+      return Promise.resolve({
+        getTracks: () => [track],
+        getVideoTracks: () => [track],
+      });
+    },
+    enumerateDevices: () =>
+      Promise.resolve([
+        {
+          kind: 'videoinput',
+          deviceId: 'fake-camera-device',
+          label: 'Fake Camera',
+        },
+      ]),
+    },
+  });
+
+  const nonNeutralFrame = {
+    faceLandmarks: createLandmarks(0.55, 0.58),
+    faceBlendshapes: [
+      {
+        categories: [
+          { categoryName: 'mouthSmileLeft', score: 0.6 },
+          { categoryName: 'mouthSmileRight', score: 0.62 },
+        ],
+      },
+    ],
+  };
+
+  const neutralFrame = {
+    faceLandmarks: createLandmarks(0.55, 0.565),
+    faceBlendshapes: [
+      {
+        categories: [
+          { categoryName: 'mouthSmileLeft', score: 0.18 },
+          { categoryName: 'mouthSmileRight', score: 0.2 },
+        ],
+      },
+    ],
+  };
+
+  let progressiveFrameIndex = 0;
+  let captureStartTimestamp = null;
+
+  win.addEventListener('click', (event) => {
+    const element = event.target;
+    if (
+      element &&
+      element.nodeType === 1 &&
+      element.id === 'start-image-capture' &&
+      captureStartTimestamp === null
+    ) {
+      captureStartTimestamp = Date.now();
+    }
+  });
+
+  const progressiveSmileFrame = () => {
+    progressiveFrameIndex += 1;
+
+    const smileBase = 0.3;
+    const mouthBase = 0.065;
+    const smile = Math.min(smileBase + progressiveFrameIndex * 0.05, 0.95);
+    const mouthOpen = Math.min(mouthBase + progressiveFrameIndex * 0.015, 0.3);
+
+    return {
+      faceLandmarks: createLandmarks(0.55, 0.55 + mouthOpen),
+      faceBlendshapes: [
+        {
+          categories: [
+            { categoryName: 'mouthSmileLeft', score: smile },
+            { categoryName: 'mouthSmileRight', score: smile },
+          ],
+        },
+      ],
+    };
+  };
+
+  const getDetectionFrame = () => {
+    if (mode === 'neutral-then-smile') {
+      const elapsedMs = captureStartTimestamp
+        ? Date.now() - captureStartTimestamp
+        : 0;
+      if (elapsedMs < switchAfterMs) {
+        return neutralFrame;
+      }
+      return progressiveSmileFrame();
+    }
+
+    return nonNeutralFrame;
+  };
+
+  win.__smileIdentityMediapipe = {
+    loaded: true,
+    loading: null,
+    instance: {
+      detectForVideo: () => getDetectionFrame(),
+    },
+  };
+
+  win.__selfiePublishEvents = 0;
+  win.addEventListener('selfie-capture.publish', () => {
+    win.__selfiePublishEvents += 1;
+  });
+};
+
+context('SmartSelfie Incremental Smile', () => {
+  afterEach(() => {
+    cy.window().then((win) => {
+      win.__restoreBrowserMocks?.();
+    });
+  });
+
+  it('pauses capture with neutral-expression alert when user smiles too early', () => {
+    cy.visit('/?component=smartselfie-capture&direct=true', {
+      onBeforeLoad: (win) => installBrowserMocks(win, 'always-smile'),
+    });
+
+    cy.get('smartselfie-capture')
+      .shadow()
+      .find('#start-image-capture', { timeout: 12000 })
+      .should('be.enabled')
+      .click();
+
+    cy.get('smartselfie-capture')
+      .shadow()
+      .find('.alert-title', { timeout: 12000 })
+      .should('contain.text', 'Neutral expression');
+
+    cy.wait(4000);
+
+    cy.window().its('__selfiePublishEvents').should('eq', 0);
+  });
+
+  it('keeps capture active when user is neutral first then progressively smiles', () => {
+    cy.visit('/?component=smartselfie-capture&direct=true&interval=350&duration=700', {
+      onBeforeLoad: (win) =>
+        installBrowserMocks(win, 'neutral-then-smile', { switchAfterMs: 500 }),
+    });
+
+    cy.get('smartselfie-capture')
+      .shadow()
+      .find('#start-image-capture', { timeout: 12000 })
+      .should('be.enabled')
+      .click();
+
+    cy.get('smartselfie-capture')
+      .shadow()
+      .find('.alert-title', { timeout: 12000 })
+      .should('contain.text', 'Capturing');
+
+    cy.wait(2500);
+
+    cy.get('smartselfie-capture')
+      .shadow()
+      .find('.alert-title')
+      .invoke('text')
+      .then((text) => {
+        expect(text).to.not.contain('Neutral expression');
+        expect(text).to.match(/Smile!|Keep smiling!/);
+      });
+  });
+});

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
@@ -43,9 +43,11 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
 
   const smileCooldown = 300;
   const smileThreshold = 0.25;
+  const neutralSmileMaxThreshold = 0.35;
   const mouthOpenThreshold = 0.05;
-  const smileProgressDelta = 0.08;
-  const smileProgressConsecutiveFrames = 4;
+  const smileProgressDelta = 0.04;
+  const mouthDeformationDelta = 0.01;
+  const smileProgressConsecutiveFrames = 3;
   const smileBaselineSampleSize = 8;
   const minFaceSize = 0.35;
   const maxFaceSize = 0.5;
@@ -66,8 +68,10 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
     interval,
     duration,
     smileThreshold,
+    neutralSmileMaxThreshold,
     mouthOpenThreshold,
     smileProgressDelta,
+    mouthDeformationDelta,
     smileProgressConsecutiveFrames,
     smileBaselineSampleSize,
     minFaceSize,

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
@@ -44,6 +44,9 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
   const smileCooldown = 300;
   const smileThreshold = 0.25;
   const mouthOpenThreshold = 0.05;
+  const smileProgressDelta = 0.08;
+  const smileProgressConsecutiveFrames = 4;
+  const smileBaselineSampleSize = 8;
   const minFaceSize = 0.35;
   const maxFaceSize = 0.5;
 
@@ -64,6 +67,9 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
     duration,
     smileThreshold,
     mouthOpenThreshold,
+    smileProgressDelta,
+    smileProgressConsecutiveFrames,
+    smileBaselineSampleSize,
     minFaceSize,
     maxFaceSize,
     smileCooldown,

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx
@@ -48,7 +48,6 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
   const smileProgressDelta = 0.04;
   const mouthDeformationDelta = 0.01;
   const smileProgressConsecutiveFrames = 3;
-  const smileBaselineSampleSize = 8;
   const minFaceSize = 0.35;
   const maxFaceSize = 0.5;
 
@@ -73,7 +72,6 @@ const SmartSelfieCapture: FunctionComponent<Props> = ({
     smileProgressDelta,
     mouthDeformationDelta,
     smileProgressConsecutiveFrames,
-    smileBaselineSampleSize,
     minFaceSize,
     maxFaceSize,
     smileCooldown,

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
@@ -28,8 +28,10 @@ interface UseFaceCaptureProps {
   interval: number;
   duration: number;
   smileThreshold: number;
+  neutralSmileMaxThreshold: number;
   mouthOpenThreshold: number;
   smileProgressDelta: number;
+  mouthDeformationDelta: number;
   smileProgressConsecutiveFrames: number;
   smileBaselineSampleSize: number;
   minFaceSize: number;
@@ -44,8 +46,10 @@ export const useFaceCapture = ({
   interval,
   duration,
   smileThreshold,
+  neutralSmileMaxThreshold,
   mouthOpenThreshold,
   smileProgressDelta,
+  mouthDeformationDelta,
   smileProgressConsecutiveFrames,
   smileBaselineSampleSize,
   minFaceSize,
@@ -58,7 +62,10 @@ export const useFaceCapture = ({
   const captureTimerRef = useRef<NodeJS.Timeout | null>(null);
   const resumeCaptureRef = useRef<(() => void) | null>(null);
   const smileBaselineSamplesRef = useRef<number[]>([]);
+  const mouthBaselineSamplesRef = useRef<number[]>([]);
   const smileConsecutiveFramesRef = useRef(0);
+  const smileZoneMinScoreRef = useRef<number | null>(null);
+  const smileZoneMinMouthOpenRef = useRef<number | null>(null);
 
   const faceDetected = useSignal(false);
   const faceInBounds = useSignal(false);
@@ -82,8 +89,11 @@ export const useFaceCapture = ({
   const capturesTaken = useSignal(0);
   const hasFinishedCapture = useSignal(false);
 
+  const livenessCaptureCount = useComputed(() =>
+    Math.max(totalCaptures.value - 1, 0),
+  );
   const smileCheckpoint = useComputed(() =>
-    Math.floor(totalCaptures.value * 0.4),
+    Math.floor(livenessCaptureCount.value / 2),
   );
   const neutralZone = useComputed(() => Math.floor(totalCaptures.value * 0.2));
 
@@ -105,47 +115,77 @@ export const useFaceCapture = ({
 
   const resetSmileProgressTracking = () => {
     smileBaselineSamplesRef.current = [];
+    mouthBaselineSamplesRef.current = [];
     smileConsecutiveFramesRef.current = 0;
+    smileZoneMinScoreRef.current = null;
+    smileZoneMinMouthOpenRef.current = null;
   };
 
-  const getSmileBaseline = () => {
-    if (!smileBaselineSamplesRef.current.length) {
-      return Math.max(0, smileThreshold - smileProgressDelta);
-    }
-
-    const total = smileBaselineSamplesRef.current.reduce(
-      (sum, score) => sum + score,
-      0,
-    );
-
-    return total / smileBaselineSamplesRef.current.length;
-  };
+  const hasLightNeutralExpression = () =>
+    currentSmileScore.value <= neutralSmileMaxThreshold &&
+    currentMouthOpen.value < mouthOpenThreshold;
 
   const trackSmileProgress = (smileScore: number, mouthOpen: number) => {
-    const isSmileZone = capturesTaken.value >= smileCheckpoint.value;
+    const isSmileZone = capturesTaken.value > smileCheckpoint.value;
     const isSmileEligible =
       smileScore >= smileThreshold && mouthOpen >= mouthOpenThreshold;
 
     if (!isCapturing.value || !isSmileZone) {
       if (
         isCapturing.value &&
-        capturesTaken.value < smileCheckpoint.value &&
+        capturesTaken.value <= smileCheckpoint.value &&
         smileBaselineSamplesRef.current.length < smileBaselineSampleSize
       ) {
         smileBaselineSamplesRef.current = [
           ...smileBaselineSamplesRef.current,
           smileScore,
         ];
+
+        mouthBaselineSamplesRef.current = [
+          ...mouthBaselineSamplesRef.current,
+          mouthOpen,
+        ];
       }
       smileConsecutiveFramesRef.current = 0;
+      smileZoneMinScoreRef.current = null;
+      smileZoneMinMouthOpenRef.current = null;
       return false;
     }
 
+    if (smileZoneMinScoreRef.current === null) {
+      smileZoneMinScoreRef.current = smileScore;
+    } else {
+      smileZoneMinScoreRef.current = Math.min(
+        smileZoneMinScoreRef.current,
+        smileScore,
+      );
+    }
+
+    if (smileZoneMinMouthOpenRef.current === null) {
+      smileZoneMinMouthOpenRef.current = mouthOpen;
+    } else {
+      smileZoneMinMouthOpenRef.current = Math.min(
+        smileZoneMinMouthOpenRef.current,
+        mouthOpen,
+      );
+    }
+
+    const smileProgressionBaseline = smileZoneMinScoreRef.current;
+    const mouthProgressionBaseline = smileZoneMinMouthOpenRef.current;
+
     const requiredSmileScore = Math.max(
       smileThreshold,
-      getSmileBaseline() + smileProgressDelta,
+      smileProgressionBaseline + smileProgressDelta,
     );
-    const hasProgressedSmile = isSmileEligible && smileScore >= requiredSmileScore;
+    const requiredMouthOpen = Math.max(
+      mouthOpenThreshold,
+      mouthProgressionBaseline + mouthDeformationDelta,
+    );
+    const hasProgressedMouth = mouthOpen >= requiredMouthOpen;
+    const hasProgressedSmile =
+      isSmileEligible &&
+      smileScore >= requiredSmileScore &&
+      hasProgressedMouth;
 
     if (hasProgressedSmile) {
       smileConsecutiveFramesRef.current += 1;
@@ -199,15 +239,24 @@ export const useFaceCapture = ({
   };
 
   const updateCaptureAlerts = () => {
-    const isInNeutralZone = capturesTaken.value < neutralZone.value;
-    const isInSmileZone = capturesTaken.value >= smileCheckpoint.value;
+    const isInNeutralZone = capturesTaken.value <= smileCheckpoint.value;
+    const isInSmileZone = capturesTaken.value > smileCheckpoint.value;
 
     if (isInNeutralZone) {
-      alertTitle.value = t('selfie.smart.status.capturing');
+      if (hasLightNeutralExpression()) {
+        alertTitle.value = t('selfie.smart.status.capturing');
+      } else {
+        updateAlert('neutral-expression');
+      }
     } else if (isInSmileZone) {
       const timeSinceSmile = Date.now() - lastSmileTime.value;
       if (timeSinceSmile > smileCooldown) {
         if (
+          currentSmileScore.value >= smileThreshold &&
+          currentMouthOpen.value >= mouthOpenThreshold
+        ) {
+          updateAlert('smile-required');
+        } else if (
           currentSmileScore.value >= smileThreshold &&
           currentMouthOpen.value < mouthOpenThreshold
         ) {
@@ -381,6 +430,26 @@ export const useFaceCapture = ({
               }
             }, 0);
           }
+        } else {
+          const isInSmileZone = capturesTaken.value > smileCheckpoint.value;
+
+          if (
+            !isInSmileZone &&
+            hasLightNeutralExpression() &&
+            isPaused.value &&
+            isCapturing.value &&
+            resumeCaptureRef.current
+          ) {
+            setTimeout(() => {
+              if (
+                isPaused.value &&
+                isCapturing.value &&
+                resumeCaptureRef.current
+              ) {
+                resumeCaptureRef.current();
+              }
+            }, 0);
+          }
         }
       } else {
         // No face detected or multiple faces - reset values
@@ -388,6 +457,7 @@ export const useFaceCapture = ({
         currentFaceSize.value = 0;
         currentMouthOpen.value = 0;
         smileConsecutiveFramesRef.current = 0;
+        smileZoneMinMouthOpenRef.current = null;
         faceInBounds.value = false;
         faceProximity.value = 'good';
       }
@@ -471,7 +541,7 @@ export const useFaceCapture = ({
     }
   };
 
-  const pauseCapture = () => {
+  const pauseCapture = (messageKey: MessageKey = 'smile-required') => {
     if (captureTimerRef.current) {
       clearInterval(captureTimerRef.current);
       captureTimerRef.current = null;
@@ -484,7 +554,7 @@ export const useFaceCapture = ({
       faceInBounds.value &&
       faceProximity.value === 'good'
     ) {
-      updateAlert('smile-required');
+      updateAlert(messageKey);
     }
   };
 
@@ -518,7 +588,12 @@ export const useFaceCapture = ({
         return;
       }
 
-      const isInSmileZone = capturesTaken.value >= smileCheckpoint.value;
+      const isInSmileZone = capturesTaken.value > smileCheckpoint.value;
+
+      if (!isInSmileZone && !hasLightNeutralExpression()) {
+        pauseCapture('neutral-expression');
+        return;
+      }
 
       if (isInSmileZone) {
         const timeSinceSmile = Date.now() - lastSmileTime.value;
@@ -539,7 +614,11 @@ export const useFaceCapture = ({
       faceInBounds.value &&
       !multipleFaces.value
     ) {
-      const isInSmileZone = capturesTaken.value >= smileCheckpoint.value;
+      const isInSmileZone = capturesTaken.value > smileCheckpoint.value;
+      if (!isInSmileZone && !hasLightNeutralExpression()) {
+        return;
+      }
+
       if (isInSmileZone) {
         const timeSinceSmile = Date.now() - lastSmileTime.value;
         if (timeSinceSmile > smileCooldown) {

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
@@ -161,9 +161,7 @@ export const useFaceCapture = ({
     );
     const hasProgressedMouth = mouthOpen >= requiredMouthOpen;
     const hasProgressedSmile =
-      isSmileEligible &&
-      smileScore >= requiredSmileScore &&
-      hasProgressedMouth;
+      isSmileEligible && smileScore >= requiredSmileScore && hasProgressedMouth;
 
     if (hasProgressedSmile) {
       smileConsecutiveFramesRef.current += 1;

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
@@ -33,7 +33,6 @@ interface UseFaceCaptureProps {
   smileProgressDelta: number;
   mouthDeformationDelta: number;
   smileProgressConsecutiveFrames: number;
-  smileBaselineSampleSize: number;
   minFaceSize: number;
   maxFaceSize: number;
   smileCooldown: number;
@@ -51,7 +50,6 @@ export const useFaceCapture = ({
   smileProgressDelta,
   mouthDeformationDelta,
   smileProgressConsecutiveFrames,
-  smileBaselineSampleSize,
   minFaceSize,
   maxFaceSize,
   smileCooldown,
@@ -61,8 +59,6 @@ export const useFaceCapture = ({
   const animationFrameRef = useRef<number | null>(null);
   const captureTimerRef = useRef<NodeJS.Timeout | null>(null);
   const resumeCaptureRef = useRef<(() => void) | null>(null);
-  const smileBaselineSamplesRef = useRef<number[]>([]);
-  const mouthBaselineSamplesRef = useRef<number[]>([]);
   const smileConsecutiveFramesRef = useRef(0);
   const smileZoneMinScoreRef = useRef<number | null>(null);
   const smileZoneMinMouthOpenRef = useRef<number | null>(null);
@@ -95,7 +91,6 @@ export const useFaceCapture = ({
   const smileCheckpoint = useComputed(() =>
     Math.floor(livenessCaptureCount.value / 2),
   );
-  const neutralZone = useComputed(() => Math.floor(totalCaptures.value * 0.2));
 
   const isReadyToCapture = useComputed(
     () =>
@@ -114,8 +109,6 @@ export const useFaceCapture = ({
   };
 
   const resetSmileProgressTracking = () => {
-    smileBaselineSamplesRef.current = [];
-    mouthBaselineSamplesRef.current = [];
     smileConsecutiveFramesRef.current = 0;
     smileZoneMinScoreRef.current = null;
     smileZoneMinMouthOpenRef.current = null;
@@ -131,21 +124,6 @@ export const useFaceCapture = ({
       smileScore >= smileThreshold && mouthOpen >= mouthOpenThreshold;
 
     if (!isCapturing.value || !isSmileZone) {
-      if (
-        isCapturing.value &&
-        capturesTaken.value <= smileCheckpoint.value &&
-        smileBaselineSamplesRef.current.length < smileBaselineSampleSize
-      ) {
-        smileBaselineSamplesRef.current = [
-          ...smileBaselineSamplesRef.current,
-          smileScore,
-        ];
-
-        mouthBaselineSamplesRef.current = [
-          ...mouthBaselineSamplesRef.current,
-          mouthOpen,
-        ];
-      }
       smileConsecutiveFramesRef.current = 0;
       smileZoneMinScoreRef.current = null;
       smileZoneMinMouthOpenRef.current = null;
@@ -252,11 +230,6 @@ export const useFaceCapture = ({
       const timeSinceSmile = Date.now() - lastSmileTime.value;
       if (timeSinceSmile > smileCooldown) {
         if (
-          currentSmileScore.value >= smileThreshold &&
-          currentMouthOpen.value >= mouthOpenThreshold
-        ) {
-          updateAlert('smile-required');
-        } else if (
           currentSmileScore.value >= smileThreshold &&
           currentMouthOpen.value < mouthOpenThreshold
         ) {
@@ -743,7 +716,6 @@ export const useFaceCapture = ({
     capturesTaken,
     hasFinishedCapture,
     smileCheckpoint,
-    neutralZone,
 
     initializeFaceLandmarker,
     setupCanvas,

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
@@ -29,6 +29,9 @@ interface UseFaceCaptureProps {
   duration: number;
   smileThreshold: number;
   mouthOpenThreshold: number;
+  smileProgressDelta: number;
+  smileProgressConsecutiveFrames: number;
+  smileBaselineSampleSize: number;
   minFaceSize: number;
   maxFaceSize: number;
   smileCooldown: number;
@@ -42,6 +45,9 @@ export const useFaceCapture = ({
   duration,
   smileThreshold,
   mouthOpenThreshold,
+  smileProgressDelta,
+  smileProgressConsecutiveFrames,
+  smileBaselineSampleSize,
   minFaceSize,
   maxFaceSize,
   smileCooldown,
@@ -51,6 +57,8 @@ export const useFaceCapture = ({
   const animationFrameRef = useRef<number | null>(null);
   const captureTimerRef = useRef<NodeJS.Timeout | null>(null);
   const resumeCaptureRef = useRef<(() => void) | null>(null);
+  const smileBaselineSamplesRef = useRef<number[]>([]);
+  const smileConsecutiveFramesRef = useRef(0);
 
   const faceDetected = useSignal(false);
   const faceInBounds = useSignal(false);
@@ -93,6 +101,59 @@ export const useFaceCapture = ({
     } else {
       alertTitle.value = '';
     }
+  };
+
+  const resetSmileProgressTracking = () => {
+    smileBaselineSamplesRef.current = [];
+    smileConsecutiveFramesRef.current = 0;
+  };
+
+  const getSmileBaseline = () => {
+    if (!smileBaselineSamplesRef.current.length) {
+      return Math.max(0, smileThreshold - smileProgressDelta);
+    }
+
+    const total = smileBaselineSamplesRef.current.reduce(
+      (sum, score) => sum + score,
+      0,
+    );
+
+    return total / smileBaselineSamplesRef.current.length;
+  };
+
+  const trackSmileProgress = (smileScore: number, mouthOpen: number) => {
+    const isSmileZone = capturesTaken.value >= smileCheckpoint.value;
+    const isSmileEligible =
+      smileScore >= smileThreshold && mouthOpen >= mouthOpenThreshold;
+
+    if (!isCapturing.value || !isSmileZone) {
+      if (
+        isCapturing.value &&
+        capturesTaken.value < smileCheckpoint.value &&
+        smileBaselineSamplesRef.current.length < smileBaselineSampleSize
+      ) {
+        smileBaselineSamplesRef.current = [
+          ...smileBaselineSamplesRef.current,
+          smileScore,
+        ];
+      }
+      smileConsecutiveFramesRef.current = 0;
+      return false;
+    }
+
+    const requiredSmileScore = Math.max(
+      smileThreshold,
+      getSmileBaseline() + smileProgressDelta,
+    );
+    const hasProgressedSmile = isSmileEligible && smileScore >= requiredSmileScore;
+
+    if (hasProgressedSmile) {
+      smileConsecutiveFramesRef.current += 1;
+    } else {
+      smileConsecutiveFramesRef.current = 0;
+    }
+
+    return smileConsecutiveFramesRef.current >= smileProgressConsecutiveFrames;
   };
 
   const updateAlert = useRef(
@@ -303,7 +364,7 @@ export const useFaceCapture = ({
         currentSmileScore.value = smileScore;
         currentMouthOpen.value = mouthOpen;
 
-        if (smileScore >= smileThreshold && mouthOpen >= mouthOpenThreshold) {
+        if (trackSmileProgress(smileScore, mouthOpen)) {
           lastSmileTime.value = Date.now();
 
           if (isPaused.value && isCapturing.value && resumeCaptureRef.current) {
@@ -326,6 +387,7 @@ export const useFaceCapture = ({
         currentSmileScore.value = 0;
         currentFaceSize.value = 0;
         currentMouthOpen.value = 0;
+        smileConsecutiveFramesRef.current = 0;
         faceInBounds.value = false;
         faceProximity.value = 'good';
       }
@@ -497,6 +559,7 @@ export const useFaceCapture = ({
     capturedImages.value = [];
     isCapturing.value = true;
     isPaused.value = false;
+    resetSmileProgressTracking();
     totalCaptures.value = Math.ceil(duration / interval);
     capturesTaken.value = 0;
     countdown.value = totalCaptures.value;
@@ -570,6 +633,7 @@ export const useFaceCapture = ({
     currentFaceSize.value = 0;
     currentMouthOpen.value = 0;
     lastSmileTime.value = 0;
+    resetSmileProgressTracking();
 
     if (canvasRef.current) {
       clearCanvas(canvasRef.current);


### PR DESCRIPTION
### **User description**
- **progressive smile implementation**
- **clean ups to bring the smile parity up to how the android sdk does capture**


___

### **PR Type**
Enhancement


___

### **Description**
- Implement incremental smile detection with progressive thresholds

- Add neutral expression enforcement during non-smile capture zones

- Track smile baseline samples and consecutive frame confirmation

- Adjust smile zone boundaries to align with Android SDK behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Face Detection"] -- "scores" --> B["Baseline Sampling"]
  B -- "neutral zone" --> C["Neutral Expression Check"]
  B -- "smile zone" --> D["Progressive Smile Tracking"]
  D -- "delta thresholds" --> E["Consecutive Frame Validation"]
  E -- "confirmed" --> F["Resume / Capture"]
  C -- "light neutral" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SmartSelfieCapture.tsx</strong><dd><code>Add incremental smile detection configuration parameters</code>&nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/smartselfie-capture/SmartSelfieCapture.tsx

<ul><li>Added new configuration constants: <code>neutralSmileMaxThreshold</code>, <br><code>smileProgressDelta</code>, <code>mouthDeformationDelta</code>, <br><code>smileProgressConsecutiveFrames</code>, <code>smileBaselineSampleSize</code><br> <li> Passed new parameters to the <code>useFaceCapture</code> hook</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/558/files#diff-98051a6d928387bdb1bc98f6a9d8845367aeb69b289e1d730824269c3b446f9f">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useFaceCapture.ts</strong><dd><code>Implement progressive smile tracking and neutral expression gating</code></dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts

<ul><li>Added <code>trackSmileProgress</code> function implementing incremental smile <br>detection with baseline sampling, progressive delta thresholds, and <br>consecutive frame confirmation<br> <li> Added <code>hasLightNeutralExpression</code> check to enforce neutral expression <br>during non-smile capture zones<br> <li> Changed smile zone boundary from <code>>=</code> to <code>></code> (<code>capturesTaken > </code><br><code>smileCheckpoint</code>) and recalculated <code>smileCheckpoint</code> as half of liveness <br>capture count<br> <li> Added refs for smile/mouth baseline samples, consecutive frames <br>counter, and zone minimum scores<br> <li> Updated <code>pauseCapture</code> to accept a <code>messageKey</code> parameter, defaulting to <br><code>'smile-required'</code><br> <li> Added neutral expression gating in <code>startCaptureInterval</code> and <br><code>resumeCapture</code> to pause/block capture when expression is not neutral<br> <li> Reset smile progress tracking state on <code>startCapture</code> and <code>resetCapture</code><br> <li> In the non-smile zone, resume capture is now triggered when a light <br>neutral expression is detected instead of requiring a smile</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/558/files#diff-ac8fe68b6164d1778c63c6a896ef6b97cabf43d7b262f9d6f973edca5c800b02">+152/-9</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>