### PR TITLE
feat: add manual workflow_dispatch trigger with skip_tests option to deploy-preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -227,6 +227,7 @@ jobs:
         working-directory: ./packages/embed
         run: echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
       - name: share preview urls as PR comment
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,14 +11,18 @@ on:
     types:
       - opened
       - synchronize
-permissions: write-all
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+  issues: write
 jobs:
   test:
     if: ${{ !inputs.skip_tests }}
     uses: ./.github/workflows/test.yml
   smart-camera-web:
     needs: [test]
-    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
     defaults:
       run:
         working-directory: ./packages/web-components
@@ -104,9 +108,11 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: set sst stage
         id: get_branch_name
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
           echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
-          BRANCH_NAME=${{ github.event.pull_request.head.ref || github.ref_name }}
+          BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> "$GITHUB_OUTPUT"
       - name: install dependencies
@@ -175,8 +181,10 @@ jobs:
         working-directory: ./previews
         run: npm install
       - name: set branch name
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          BRANCH_NAME=${{ github.event.pull_request.head.ref || github.ref_name }}
+          BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> "$GITHUB_ENV"
       - name: retrieve sst app url

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,7 @@ permissions:
   issues: write
 jobs:
   test:
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.skip_tests }}
     uses: ./.github/workflows/test.yml
   smart-camera-web:
     needs: [test]

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,12 @@
 name: deploy-preview
 on:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests before deploying'
+        type: boolean
+        default: false
   pull_request:
     types:
       - opened
@@ -8,9 +14,11 @@ on:
 permissions: write-all
 jobs:
   test:
+    if: ${{ !inputs.skip_tests }}
     uses: ./.github/workflows/test.yml
   smart-camera-web:
     needs: [test]
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     defaults:
       run:
         working-directory: ./packages/web-components
@@ -27,7 +35,7 @@ jobs:
       - name: set destination directory
         id: set_dest_dir_smart_camera_web
         run: >-
-          echo "DEST_DIR_SMART_CAMERA_WEB=js/preview-$GITHUB_HEAD_REF" >>
+          echo "DEST_DIR_SMART_CAMERA_WEB=js/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >>
           "$GITHUB_ENV"
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -62,7 +70,7 @@ jobs:
         run: npm run build && npm run build:dist
       - name: set destination directory
         id: set_dest_dir_hosted_web
-        run: echo "DEST_DIR_EMBED=inline/preview-$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
+        run: echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -97,8 +105,8 @@ jobs:
       - name: set sst stage
         id: get_branch_name
         run: |
-          echo "DEST_DIR_EMBED=inline/preview-$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
-          BRANCH_NAME=${{ github.event.pull_request.head.ref }}
+          echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          BRANCH_NAME=${{ github.event.pull_request.head.ref || github.ref_name }}
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> "$GITHUB_OUTPUT"
       - name: install dependencies
@@ -168,7 +176,7 @@ jobs:
         run: npm install
       - name: set branch name
         run: |
-          BRANCH_NAME=${{ github.event.pull_request.head.ref }}
+          BRANCH_NAME=${{ github.event.pull_request.head.ref || github.ref_name }}
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> "$GITHUB_ENV"
       - name: retrieve sst app url
@@ -204,12 +212,12 @@ jobs:
         id: get_dest_dir_smart_camera_web
         working-directory: ./packages/smart-camera-web
         run: >-
-          echo "DEST_DIR_SMART_CAMERA_WEB=js/preview-$GITHUB_HEAD_REF" >>
+          echo "DEST_DIR_SMART_CAMERA_WEB=js/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >>
           "$GITHUB_ENV"
       - name: get dest dir for web embed
         id: get_dest_dir_embed
         working-directory: ./packages/embed
-        run: echo "DEST_DIR_EMBED=inline/preview-$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
+        run: echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
       - name: share preview urls as PR comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -73,7 +73,7 @@ jobs:
           SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
         run: npm run build && npm run build:dist
       - name: set destination directory
-        id: set_dest_dir_hosted_web
+        id: set_dest_dir_embed
         run: echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -1,6 +1,7 @@
 name: destroy-preview
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -26,8 +27,10 @@ jobs:
           curl -fsSL https://ion.sst.dev/install | VERSION=3.4.5 bash
       - name: set sst stage
         id: get_branch_name
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          BRANCH_NAME=${{ github.event.pull_request.head.ref }}
+          BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "SS_STAGE=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
       - name: install dependencies


### PR DESCRIPTION
### **User description**
## Summary
Adds a `workflow_dispatch` trigger to the `deploy-preview` workflow so it can be run manually from the GitHub Actions UI without opening a PR.
## Changes
 - **`workflow_dispatch` trigger** with a `skip_tests` boolean input (default: `false`) 
 - allows manually triggering a deploy preview with or without running tests first.
- **`test` job** is now conditional on `skip_tests` not being set.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `workflow_dispatch` trigger with `skip_tests` option

- Make test job conditional on `skip_tests` input

- Handle missing `GITHUB_HEAD_REF` with fallback to `GITHUB_REF_NAME`

- Allow deploy job to proceed when tests are skipped


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["workflow_dispatch trigger"]
  skipInput["skip_tests input"]
  testJob["test job (conditional)"]
  deployJobs["deploy jobs"]
  refFallback["GITHUB_HEAD_REF fallback to GITHUB_REF_NAME"]
  trigger -- "provides" --> skipInput
  skipInput -- "if false" --> testJob
  testJob -- "success or skipped" --> deployJobs
  refFallback -- "ensures branch name" --> deployJobs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-preview.yml</strong><dd><code>Manual dispatch trigger and branch ref fallback handling</code>&nbsp; </dd></summary>
<hr>

.github/workflows/deploy-preview.yml

<ul><li>Added <code>workflow_dispatch</code> trigger with a <code>skip_tests</code> boolean input <br>(default <code>false</code>)<br> <li> Made the <code>test</code> job conditional with <code>if: ${{ !inputs.skip_tests }}</code><br> <li> Added <code>if: always() && (needs.test.result == 'success' || </code><br><code>needs.test.result == 'skipped')</code> to <code>smart-camera-web</code> job so it runs <br>when tests are skipped<br> <li> Replaced all <code>$GITHUB_HEAD_REF</code> references with <br><code>${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}</code> and <br><code>github.event.pull_request.head.ref</code> with <br><code>github.event.pull_request.head.ref || github.ref_name</code> to support <br>non-PR contexts</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/586/files#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0">+15/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>