### PR TITLE
fix(previews): build web-components before embed in dev-mobile script

### DIFF
--- a/previews/scripts/dev-mobile.sh
+++ b/previews/scripts/dev-mobile.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 PREVIEWS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "$PREVIEWS_DIR/.." && pwd)"
 EMBED_DIR="$REPO_ROOT/packages/embed"
+WEB_COMPONENTS_DIR="$REPO_ROOT/packages/web-components"
 
 if ! command -v cloudflared >/dev/null 2>&1; then
   echo "❌ cloudflared not found. Install it first:"
@@ -29,6 +30,11 @@ fi
 
 if [ ! -d "$EMBED_DIR" ]; then
   echo "❌ Embed package not found at $EMBED_DIR"
+  exit 1
+fi
+
+if [ ! -d "$WEB_COMPONENTS_DIR" ]; then
+  echo "❌ web-components package not found at $WEB_COMPONENTS_DIR"
   exit 1
 fi
 
@@ -68,7 +74,15 @@ wait_for_tunnel_url() {
 }
 
 echo "📦 Starting embed dev server (port 8000)..."
-(cd "$EMBED_DIR" && npm start) > "$EMBED_LOG" 2>&1 &
+echo "   Building @smileid/web-components first (embed depends on its dist/ output)..."
+(
+  cd "$WEB_COMPONENTS_DIR"
+  if [ ! -d node_modules ]; then
+    npm ci
+  fi
+  npm run build
+) > "$EMBED_LOG" 2>&1
+(cd "$EMBED_DIR" && npm start) >> "$EMBED_LOG" 2>&1 &
 PIDS+=($!)
 
 echo "🌩  Opening Cloudflare tunnel for embed (port 8000)..."

--- a/previews/scripts/dev-mobile.sh
+++ b/previews/scripts/dev-mobile.sh
@@ -73,16 +73,23 @@ wait_for_tunnel_url() {
   return 1
 }
 
-echo "📦 Starting embed dev server (port 8000)..."
-echo "   Building @smileid/web-components first (embed depends on its dist/ output)..."
+echo "� Building @smileid/web-components (embed depends on its dist/ output)..."
+# Workspace deps live at $REPO_ROOT/node_modules; only run an install if the
+# root install hasn't happened yet. Stream build output to the terminal so
+# failures are immediately visible.
 (
-  cd "$WEB_COMPONENTS_DIR"
+  cd "$REPO_ROOT"
   if [ ! -d node_modules ]; then
     npm ci
   fi
-  npm run build
-) > "$EMBED_LOG" 2>&1
-(cd "$EMBED_DIR" && npm start) >> "$EMBED_LOG" 2>&1 &
+  npm run build --workspace=@smileid/web-components
+) || {
+  echo "❌ web-components build failed; aborting." >&2
+  exit 1
+}
+
+echo "📦 Starting embed dev server (port 8000)..."
+(cd "$EMBED_DIR" && npm start) > "$EMBED_LOG" 2>&1 &
 PIDS+=($!)
 
 echo "🌩  Opening Cloudflare tunnel for embed (port 8000)..."

--- a/previews/scripts/dev-mobile.sh
+++ b/previews/scripts/dev-mobile.sh
@@ -73,7 +73,7 @@ wait_for_tunnel_url() {
   return 1
 }
 
-echo "� Building @smileid/web-components (embed depends on its dist/ output)..."
+echo "📦 Building @smileid/web-components (embed depends on its dist/ output)..."
 # Workspace deps live at $REPO_ROOT/node_modules; only run an install if the
 # root install hasn't happened yet. Stream build output to the terminal so
 # failures are immediately visible.


### PR DESCRIPTION
### **User description**
The `dev:mobile` script starts the embed dev server, but `@smileid/embed` imports from `@smileid/web-components/*` which resolves to that package's `dist/esm/` output. Without a prior build the embed fails or serves stale output.

This mirrors the [deploy-preview workflow](.github/workflows/deploy-preview.yml) by running `npm ci` (if needed) and `npm run build` in `packages/web-components` before launching the embed dev server.


___

### **PR Type**
Bug fix


___

### **Description**
- Build web-components before starting embed dev server

- Add directory existence check for web-components package

- Run `npm ci` if node_modules missing in web-components

- Mirrors deploy-preview workflow dependency build step


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dev-mobile.sh"] -- "check exists" --> B["web-components dir"]
  B -- "npm ci (if needed)" --> C["install deps"]
  C -- "npm run build" --> D["web-components dist/"]
  D -- "then start" --> E["embed dev server"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev-mobile.sh</strong><dd><code>Build web-components dependency before embed dev server</code>&nbsp; &nbsp; </dd></summary>
<hr>

previews/scripts/dev-mobile.sh

<ul><li>Added <code>WEB_COMPONENTS_DIR</code> variable pointing to <code>packages/web-components</code><br> <li> Added existence check for the web-components directory<br> <li> Added a build step that runs <code>npm ci</code> (if <code>node_modules</code> is missing) and <br><code>npm run build</code> in web-components before starting the embed dev server<br> <li> Changed embed log redirection from <code>></code> to <code>>></code> so the build output and <br>server output share the same log file</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/607/files#diff-aca3d438ecd426c454eb639f7d9e551b6170bb228264785633bf26d99a980c93">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>