### PR TITLE
fix(combobox): use input event for filtering to support Huawei devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3059,7 +3059,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -3073,7 +3074,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -3087,7 +3089,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -3101,7 +3104,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -3115,7 +3119,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -3129,7 +3134,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -3143,7 +3149,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -3157,7 +3164,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -3171,7 +3179,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -3185,7 +3194,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -3199,7 +3209,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -3213,7 +3224,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -3227,7 +3239,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -3241,7 +3254,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -3255,7 +3269,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -3269,7 +3284,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -3283,7 +3299,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -3310,7 +3327,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -3324,7 +3342,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -3338,7 +3357,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3352,7 +3372,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3366,7 +3387,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3380,7 +3402,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3394,7 +3417,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/packages/web-components/cypress/e2e/combobox.cy.js
+++ b/packages/web-components/cypress/e2e/combobox.cy.js
@@ -8,20 +8,38 @@ describe('Combobox', () => {
     it('filters options when typing in the input', () => {
       cy.get('smileid-combobox-trigger input').type('nig');
 
-      cy.get('smileid-combobox-option[value="NG"]').should('not.have.attr', 'hidden');
-      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
-      cy.get('smileid-combobox-option[value="KE"]').should('have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="NG"]').should(
+        'not.have.attr',
+        'hidden',
+      );
+      cy.get('smileid-combobox-option[value="GH"]').should(
+        'have.attr',
+        'hidden',
+      );
+      cy.get('smileid-combobox-option[value="KE"]').should(
+        'have.attr',
+        'hidden',
+      );
     });
 
     it('shows all options when search is cleared', () => {
       cy.get('smileid-combobox-trigger input').type('nig');
-      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="GH"]').should(
+        'have.attr',
+        'hidden',
+      );
 
       cy.get('smileid-combobox-trigger input').clear();
       cy.get('smileid-combobox-trigger input').trigger('input');
 
-      cy.get('smileid-combobox-option[value="GH"]').should('not.have.attr', 'hidden');
-      cy.get('smileid-combobox-option[value="NG"]').should('not.have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="GH"]').should(
+        'not.have.attr',
+        'hidden',
+      );
+      cy.get('smileid-combobox-option[value="NG"]').should(
+        'not.have.attr',
+        'hidden',
+      );
     });
 
     it('shows empty state when no options match', () => {
@@ -42,17 +60,34 @@ describe('Combobox', () => {
         $input[0].dispatchEvent(new Event('input', { bubbles: true }));
       });
 
-      cy.get('smileid-combobox-option[value="KE"]').should('not.have.attr', 'hidden');
-      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
-      cy.get('smileid-combobox-option[value="NG"]').should('have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="KE"]').should(
+        'not.have.attr',
+        'hidden',
+      );
+      cy.get('smileid-combobox-option[value="GH"]').should(
+        'have.attr',
+        'hidden',
+      );
+      cy.get('smileid-combobox-option[value="NG"]').should(
+        'have.attr',
+        'hidden',
+      );
     });
 
     it('opens the listbox when typing starts', () => {
-      cy.get('smileid-combobox-trigger').should('have.attr', 'expanded', 'false');
+      cy.get('smileid-combobox-trigger').should(
+        'have.attr',
+        'expanded',
+        'false',
+      );
 
       cy.get('smileid-combobox-trigger input').type('g');
 
-      cy.get('smileid-combobox-trigger').should('have.attr', 'expanded', 'true');
+      cy.get('smileid-combobox-trigger').should(
+        'have.attr',
+        'expanded',
+        'true',
+      );
     });
   });
 });

--- a/packages/web-components/cypress/e2e/combobox.cy.js
+++ b/packages/web-components/cypress/e2e/combobox.cy.js
@@ -1,0 +1,58 @@
+describe('Combobox', () => {
+  beforeEach(() => {
+    cy.visit('/cypress/pages/combobox-test.html');
+    cy.get('smileid-combobox').should('exist');
+  });
+
+  describe('country select filtering', () => {
+    it('filters options when typing in the input', () => {
+      cy.get('smileid-combobox-trigger input').type('nig');
+
+      cy.get('smileid-combobox-option[value="NG"]').should('not.have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="KE"]').should('have.attr', 'hidden');
+    });
+
+    it('shows all options when search is cleared', () => {
+      cy.get('smileid-combobox-trigger input').type('nig');
+      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
+
+      cy.get('smileid-combobox-trigger input').clear();
+      cy.get('smileid-combobox-trigger input').trigger('input');
+
+      cy.get('smileid-combobox-option[value="GH"]').should('not.have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="NG"]').should('not.have.attr', 'hidden');
+    });
+
+    it('shows empty state when no options match', () => {
+      cy.get('smileid-combobox-trigger input').type('zzz');
+
+      cy.get('smileid-combobox-listbox #empty-state').should('exist');
+      cy.get('smileid-combobox-option').each(($el) => {
+        cy.wrap($el).should('have.attr', 'hidden');
+      });
+    });
+
+    // Regression test: Huawei devices fire `input` events but keyup key === 'Unidentified'
+    // Filtering must work via the `input` event alone, without a valid keyup key.
+    it('filters options when input event fires without a keyup (Huawei soft keyboard)', () => {
+      cy.get('smileid-combobox-trigger input').then(($input) => {
+        // Directly set the value and fire only an input event — no keyup
+        $input[0].value = 'ken';
+        $input[0].dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      cy.get('smileid-combobox-option[value="KE"]').should('not.have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="GH"]').should('have.attr', 'hidden');
+      cy.get('smileid-combobox-option[value="NG"]').should('have.attr', 'hidden');
+    });
+
+    it('opens the listbox when typing starts', () => {
+      cy.get('smileid-combobox-trigger').should('have.attr', 'expanded', 'false');
+
+      cy.get('smileid-combobox-trigger input').type('g');
+
+      cy.get('smileid-combobox-trigger').should('have.attr', 'expanded', 'true');
+    });
+  });
+});

--- a/packages/web-components/cypress/pages/combobox-test.html
+++ b/packages/web-components/cypress/pages/combobox-test.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Combobox Test Page</title>
+  </head>
+  <body>
+    <smileid-combobox id="country-select">
+      <smileid-combobox-trigger type="text" label="Select Country"></smileid-combobox-trigger>
+      <smileid-combobox-listbox>
+        <smileid-combobox-option value="GH" label="Ghana">Ghana</smileid-combobox-option>
+        <smileid-combobox-option value="KE" label="Kenya">Kenya</smileid-combobox-option>
+        <smileid-combobox-option value="NG" label="Nigeria">Nigeria</smileid-combobox-option>
+        <smileid-combobox-option value="ZA" label="South Africa">South Africa</smileid-combobox-option>
+        <smileid-combobox-option value="UG" label="Uganda">Uganda</smileid-combobox-option>
+      </smileid-combobox-listbox>
+    </smileid-combobox>
+
+    <script type="module">
+      import '../../lib/components/combobox/src/index.js';
+    </script>
+  </body>
+</html>

--- a/packages/web-components/cypress/pages/combobox-test.html
+++ b/packages/web-components/cypress/pages/combobox-test.html
@@ -7,13 +7,26 @@
   </head>
   <body>
     <smileid-combobox id="country-select">
-      <smileid-combobox-trigger type="text" label="Select Country"></smileid-combobox-trigger>
+      <smileid-combobox-trigger
+        type="text"
+        label="Select Country"
+      ></smileid-combobox-trigger>
       <smileid-combobox-listbox>
-        <smileid-combobox-option value="GH" label="Ghana">Ghana</smileid-combobox-option>
-        <smileid-combobox-option value="KE" label="Kenya">Kenya</smileid-combobox-option>
-        <smileid-combobox-option value="NG" label="Nigeria">Nigeria</smileid-combobox-option>
-        <smileid-combobox-option value="ZA" label="South Africa">South Africa</smileid-combobox-option>
-        <smileid-combobox-option value="UG" label="Uganda">Uganda</smileid-combobox-option>
+        <smileid-combobox-option value="GH" label="Ghana"
+          >Ghana</smileid-combobox-option
+        >
+        <smileid-combobox-option value="KE" label="Kenya"
+          >Kenya</smileid-combobox-option
+        >
+        <smileid-combobox-option value="NG" label="Nigeria"
+          >Nigeria</smileid-combobox-option
+        >
+        <smileid-combobox-option value="ZA" label="South Africa"
+          >South Africa</smileid-combobox-option
+        >
+        <smileid-combobox-option value="UG" label="Uganda"
+          >Uganda</smileid-combobox-option
+        >
       </smileid-combobox-listbox>
     </smileid-combobox>
 

--- a/packages/web-components/lib/components/combobox/src/Combobox.js
+++ b/packages/web-components/lib/components/combobox/src/Combobox.js
@@ -79,6 +79,7 @@ class ComboboxTrigger extends HTMLElement {
 
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleInput = this.handleInput.bind(this);
     this.handleSelection = this.handleSelection.bind(this);
 
     this.toggleExpansionState = this.toggleExpansionState.bind(this);
@@ -139,6 +140,7 @@ class ComboboxTrigger extends HTMLElement {
 
       this.inputTrigger.addEventListener('keydown', this.handleKeyDown);
       this.inputTrigger.addEventListener('keyup', this.handleKeyUp);
+      this.inputTrigger.addEventListener('input', this.handleInput);
       this.inputTrigger.addEventListener('change', (e) => e.stopPropagation());
     }
 
@@ -159,6 +161,7 @@ class ComboboxTrigger extends HTMLElement {
     if (this.inputTrigger) {
       this.inputTrigger.removeEventListener('keydown', this.handleKeyDown);
       this.inputTrigger.removeEventListener('keyup', this.handleKeyUp);
+      this.inputTrigger.removeEventListener('input', this.handleInput);
       this.inputTrigger.removeEventListener('change', (e) =>
         e.stopPropagation(),
       );
@@ -245,10 +248,6 @@ class ComboboxTrigger extends HTMLElement {
   }
 
   handleKeyUp(event) {
-    const { key } = event;
-
-    const isPrintableCharacter = (str) => str.length === 1 && str.match(/\S| /);
-
     if (event.key === 'Escape' || event.key === 'Esc') {
       event.preventDefault();
       if (this.getAttribute('expanded') === 'true') {
@@ -261,11 +260,11 @@ class ComboboxTrigger extends HTMLElement {
         );
       }
     }
+  }
 
-    if (isPrintableCharacter(key) || key === 'Backspace') {
-      this.resetListbox();
-      this.filterListbox(event.target.value);
-    }
+  handleInput(event) {
+    this.resetListbox();
+    this.filterListbox(event.target.value);
   }
 
   toggleExpansionState() {

--- a/packages/web-components/lib/components/combobox/src/Combobox.js
+++ b/packages/web-components/lib/components/combobox/src/Combobox.js
@@ -80,6 +80,7 @@ class ComboboxTrigger extends HTMLElement {
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleInput = this.handleInput.bind(this);
+    this.handleChange = this.handleChange.bind(this);
     this.handleSelection = this.handleSelection.bind(this);
 
     this.toggleExpansionState = this.toggleExpansionState.bind(this);
@@ -141,7 +142,7 @@ class ComboboxTrigger extends HTMLElement {
       this.inputTrigger.addEventListener('keydown', this.handleKeyDown);
       this.inputTrigger.addEventListener('keyup', this.handleKeyUp);
       this.inputTrigger.addEventListener('input', this.handleInput);
-      this.inputTrigger.addEventListener('change', (e) => e.stopPropagation());
+      this.inputTrigger.addEventListener('change', this.handleChange);
     }
 
     this.listbox = this.parentElement.querySelector('smileid-combobox-listbox');
@@ -162,9 +163,7 @@ class ComboboxTrigger extends HTMLElement {
       this.inputTrigger.removeEventListener('keydown', this.handleKeyDown);
       this.inputTrigger.removeEventListener('keyup', this.handleKeyUp);
       this.inputTrigger.removeEventListener('input', this.handleInput);
-      this.inputTrigger.removeEventListener('change', (e) =>
-        e.stopPropagation(),
-      );
+      this.inputTrigger.removeEventListener('change', this.handleChange);
     }
 
     if (this.options) {
@@ -265,6 +264,10 @@ class ComboboxTrigger extends HTMLElement {
   handleInput(event) {
     this.resetListbox();
     this.filterListbox(event.target.value);
+  }
+
+  handleChange(event) {
+    event.stopPropagation();
   }
 
   toggleExpansionState() {


### PR DESCRIPTION
### **User description**
## Problem

On Huawei (and some other Android) devices, the soft keyboard fires `keyup` events with `key === 'Unidentified'` instead of the actual character. The previous filtering logic relied on `isPrintableCharacter(key)` in the `keyup` handler, which always returned `false` on these devices — so typing in the country select input had no effect.

## Fix

Replace the `keyup`-based filtering with an `input` event listener, which fires reliably on all platforms whenever the input value actually changes. The `keyup` handler is retained only for Escape key handling.

## Changes

- `packages/web-components/lib/components/combobox/src/Combobox.js`
  - Add `handleInput` method that calls `filterListbox` on every `input` event
  - Remove `isPrintableCharacter` check and filtering from `handleKeyUp`
  - Register/deregister the `input` listener in `connectedCallback` / `disconnectedCallback`

## Tests

- `packages/web-components/cypress/e2e/combobox.cy.js` — new regression test suite covering:
  - Filtering options by typing (standard keyboards)
  - Restoring all options when input is cleared
  - Empty state when no options match
  - **Huawei regression**: fires only an `input` event (no `keyup`) and asserts filtering still works
  - Listbox opens when typing starts


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace `keyup`-based filtering with `input` event for cross-device compatibility

- Fix combobox filtering on Huawei/Android devices with `key === 'Unidentified'`

- Add Cypress regression tests for combobox filtering behavior

- Add dedicated HTML test page for combobox component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User types in combobox"] -- "previously" --> B["keyup event handler"]
  B -- "isPrintableCharacter check" --> C["filterListbox"]
  A -- "now" --> D["input event handler"]
  D -- "always fires" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Combobox.js</strong><dd><code>Replace keyup filtering with input event handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/combobox/src/Combobox.js

<ul><li>Added <code>handleInput</code> method that calls <code>resetListbox</code> and <code>filterListbox</code> on <br><code>input</code> events<br> <li> Removed <code>isPrintableCharacter</code> check and filtering logic from <br><code>handleKeyUp</code><br> <li> Bound <code>handleInput</code> in constructor and registered/deregistered <code>input</code> <br>listener in lifecycle callbacks<br> <li> <code>handleKeyUp</code> now only handles Escape key</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/609/files#diff-5222011efa3a953c4d1b2d5ee8ca98b6b2ae0bd6360e8ece2a282b74969c1356">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>combobox.cy.js</strong><dd><code>Add Cypress regression tests for combobox filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/cypress/e2e/combobox.cy.js

<ul><li>New Cypress test suite for combobox filtering functionality<br> <li> Tests filtering by typing, clearing input, empty state, and listbox <br>opening<br> <li> Includes Huawei regression test that dispatches only <code>input</code> event <br>without <code>keyup</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/609/files#diff-48efa657e3741b8ea418c9f5ea95bae1897bcbfd8ea49850c0ec8a1d0338a5ab">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>combobox-test.html</strong><dd><code>Add combobox test fixture HTML page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/cypress/pages/combobox-test.html

<ul><li>New HTML test page with a <code>smileid-combobox</code> component containing <br>country options<br> <li> Imports the combobox component module for Cypress testing</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/609/files#diff-3393ac7df13097efa37d3cfcef3b3cd656f7173f65ff05ad339343cd49529e58">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>