### PR TITLE
feat(embed): report WASM init failures + tag third-party events in Sentry

### DIFF
--- a/packages/embed/src/js/request.js
+++ b/packages/embed/src/js/request.js
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/browser';
+
 const WASM_PATH = 'https://secure.smileidentity.com/web_client_guard_bg.wasm';
 const JS_PATH = 'https://secure.smileidentity.com/web_client_guard.js';
 const INTEGRITY_PATH = 'https://secure.smileidentity.com/integrity.json';
@@ -19,6 +21,10 @@ async function initWasm(forceRefetch = false) {
 
   if (!wasmModule || isStale() || forceRefetch) {
     wasmInitPromise = (async () => {
+      // Track which step we're in so the Sentry tag below points at the
+      // specific failure mode (fetch failure vs integrity mismatch vs
+      // instantiate / compile error).
+      let step = 'fetch';
       try {
         const cacheBuster = `?v=${now}`;
 
@@ -33,6 +39,7 @@ async function initWasm(forceRefetch = false) {
           );
         }
 
+        step = 'integrity';
         const { hash: expectedHash } = await integrityResponse.json();
         const wasmBuffer = await wasmResponse.arrayBuffer();
 
@@ -46,12 +53,21 @@ async function initWasm(forceRefetch = false) {
           throw new Error('WASM integrity check failed');
         }
 
+        step = 'instantiate';
         const newModule = await import(`${JS_PATH}${cacheBuster}`);
 
         await newModule.default(wasmBuffer);
 
         wasmModule = newModule;
         lastFetchTime = now;
+      } catch (e) {
+        // Report WASM init failures so we can attribute them. Without this,
+        // every signed API call downstream fails opaquely and the user-facing
+        // error is something generic like "Failed to get supported ID types".
+        Sentry.captureException(e, {
+          tags: { area: 'wasm_init', wasmStep: step },
+        });
+        throw e;
       } finally {
         wasmInitPromise = null;
       }

--- a/packages/embed/src/js/script.js
+++ b/packages/embed/src/js/script.js
@@ -2,21 +2,29 @@ import * as Sentry from '@sentry/browser';
 
 Sentry.init({
   beforeSend(event) {
-    // Check if the error originates from the library's source files
-    if (event.exception && event.exception.values) {
-      const isLibraryError = event.exception.values.some((exception) => {
-        return exception.stacktrace?.frames?.some((frame) =>
-          frame.filename.includes('inline/src'),
-        );
-      });
-
-      // If the error is from the library, send it to Sentry
-      if (isLibraryError) {
-        return event;
+    // Tag every event with its origin (library vs third-party frame) so we
+    // can slice in Sentry. Library events go through unchanged. Third-party
+    // events are now SAMPLED at 5% rather than dropped outright — without
+    // some sample we have no signal on silent failures whose stacktraces
+    // originate in browser internals (WASM compile errors, getUserMedia
+    // rejections, fetch internals), which is exactly the cohort we need to
+    // see to investigate customer-reported "camera UI loads, nothing
+    // happens" failures.
+    if (event.exception?.values) {
+      const hasLibFrame = event.exception.values.some((exception) =>
+        exception.stacktrace?.frames?.some((frame) =>
+          frame.filename?.includes('inline/src'),
+        ),
+      );
+      event.tags = {
+        ...event.tags,
+        source: hasLibFrame ? 'library' : 'third-party-frame',
+      };
+      if (!hasLibFrame && Math.random() > 0.05) {
+        return null;
       }
     }
-    // Otherwise, do not send the error
-    return null;
+    return event;
   },
   dsn: 'https://82cc89f6d5a076c26d3a3cdc03a8d954@o1154186.ingest.us.sentry.io/4507143981236224',
   integrations: [

--- a/packages/embed/src/js/script.js
+++ b/packages/embed/src/js/script.js
@@ -10,27 +10,45 @@ Sentry.init({
     // rejections, fetch internals), which is exactly the cohort we need to
     // see to investigate customer-reported "camera UI loads, nothing
     // happens" failures.
-    if (event.exception?.values) {
-      const hasLibFrame = event.exception.values.some((exception) =>
-        exception.stacktrace?.frames?.some((frame) =>
-          frame.filename?.includes('inline/src'),
-        ),
-      );
-      event.tags = {
-        ...event.tags,
-        source: hasLibFrame ? 'library' : 'third-party-frame',
-      };
-      if (!hasLibFrame && Math.random() > 0.05) {
-        return null;
-      }
+
+    // Events without an exception (Sentry.captureMessage, breadcrumbs-only)
+    // are explicit library calls — always treat as library so they reach
+    // Sentry rather than being silently dropped by the third-party sampler.
+    if (!event.exception?.values) {
+      event.tags = { ...event.tags, source: 'library' };
+      return event;
+    }
+
+    // WASM init failures (tagged in request.js) typically originate in
+    // browser internals and would otherwise be classified as third-party
+    // and sampled at 5% — but they're the exact cohort we instrumented
+    // for, so always let them through and tag as library.
+    const isWasmInit = event.tags?.area === 'wasm_init';
+    const hasLibFrame = event.exception.values.some((exception) =>
+      exception.stacktrace?.frames?.some((frame) =>
+        frame.filename?.includes('inline/src'),
+      ),
+    );
+    const treatAsLibrary = hasLibFrame || isWasmInit;
+    event.tags = {
+      ...event.tags,
+      source: treatAsLibrary ? 'library' : 'third-party-frame',
+    };
+    if (!treatAsLibrary && Math.random() > 0.05) {
+      return null;
     }
     return event;
   },
   dsn: 'https://82cc89f6d5a076c26d3a3cdc03a8d954@o1154186.ingest.us.sentry.io/4507143981236224',
   integrations: [
+    // `apply-tag-if-contains-third-party-frames` (not the previous
+    // `drop-error-if-contains-third-party-frames`) — the drop variant
+    // discards events before our beforeSend gets a chance, which would
+    // negate the 5% third-party sampling above. We tag instead and rely
+    // on beforeSend for the final keep/drop decision.
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['smileid-web-client'],
-      behaviour: 'drop-error-if-contains-third-party-frames',
+      behaviour: 'apply-tag-if-contains-third-party-frames',
     }),
   ],
   tracesSampleRate: 0.01,


### PR DESCRIPTION
### **User description**
## Summary

Two surgical changes to close blind spots in the embed package's Sentry instrumentation:

### 1. `request.js` — Sentry around `initWasm()`

`initWasm()` previously had a `try { ... } finally { ... }` with **no catch**, so failures bubbled up opaquely. Because every signed API call (`/products_config`, image upload, etc.) gates on `initWasm()` resolving, a WASM compile or fetch failure cascades into a generic `"Failed to get supported ID types"` error from the product entry files (`biometric-kyc.js` et al) with no Sentry attribution at the actual failure point.

This PR adds a `catch` that captures the exception, tags it with the step that failed (`fetch` / `integrity` / `instantiate`), and re-throws so callers see the same error as before.

```js
let step = 'fetch';
try {
  // fetch wasm + integrity ...
  step = 'integrity';
  // verify hash ...
  step = 'instantiate';
  await newModule.default(wasmBuffer);
  // ...
} catch (e) {
  Sentry.captureException(e, {
    tags: { area: 'wasm_init', wasmStep: step },
  });
  throw e;
}
```

**Real-world context:** `WEB-CLIENT-Q7` (`CompileError: WebAssembly invalid value type 'externref'`, ~5,100 events / 60d) fires from this path on old Android browsers that can't compile the guard WASM with reference-types. Today those events have no partner_id, no step attribution, and aren't correlated with the downstream user-facing failure.

### 2. `script.js` — relax the `beforeSend` filter

The previous filter dropped every event whose stacktrace didn't contain an `inline/src` frame. That's correct on its face but throws away exactly the events we need to investigate silent failures whose stacktraces originate in browser internals (WASM compile errors, getUserMedia rejections, fetch internals).

The new filter tags each event with `source=library` or `source=third-party-frame` and **samples third-party events at 5% rather than dropping them outright**. Library events go through unchanged.

```js
if (event.exception?.values) {
  const hasLibFrame = event.exception.values.some((exception) =>
    exception.stacktrace?.frames?.some((frame) =>
      frame.filename?.includes('inline/src'),
    ),
  );
  event.tags = {
    ...event.tags,
    source: hasLibFrame ? 'library' : 'third-party-frame',
  };
  if (!hasLibFrame && Math.random() > 0.05) {
    return null;
  }
}
return event;
```

The 5% sample keeps quota impact small while preserving enough signal to slice third-party failure modes in Sentry Discover.

## Risk

Low. Both changes are observability-only — no behavior change to the SDK's user-facing flow. The `script.js` change does increase Sentry event volume marginally for third-party events that were previously dropped (5% sample over a baseline that is heavily library-dominated).

## Test plan

- [x] Lint: my changes add zero new lint errors. The single `consistent-return` warning on `request.js` line 15 is pre-existing on `main` (verified by stashing and re-linting). All other apparent lint errors were the workspace import-resolver missing a transitive `resolve.exports` dep — also pre-existing and unrelated to this change.
- [x] Prettier: `npx prettier --check src/js/request.js src/js/script.js` → "All files formatted correctly"
- [ ] Manual: trigger WASM init failure (e.g., block `*.smileidentity.com` in devtools) → confirm Sentry event tagged `area: wasm_init` with the appropriate `wasmStep`
- [ ] Manual: trigger a browser-internal error not in `inline/src` → confirm 5% of these now reach Sentry, tagged `source: third-party-frame`
- [ ] Manual: trigger a library error → confirm it still reaches Sentry, now also tagged `source: library`

## PR series

This is PR 2 of 3 closing observability gaps surfaced by an investigation into customer-reported "users hit KYC capture screen, no callback received" failures.

- **PR 1** (#610) — `feat(smart-camera-web): report camera-init failures to Sentry`
- **PR 2** (this one) — embed-level Sentry hardening
- **PR 3** (coming) — tag which of `/products_config` vs `/services` actually failed in each product entry file, plus tag `partner_id` at iframe postMessage receipt so child-page errors are attributable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Sentry error reporting for WASM init failures with step attribution

- Relax beforeSend filter to sample third-party events at 5% instead of dropping

- Tag events with `source: library` or `source: third-party-frame` for slicing

- Track WASM failure step (fetch/integrity/instantiate) via tagged exception


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["initWasm()"] -- "catch error" --> B["Sentry.captureException"]
  B -- "tags: wasmStep" --> C["Sentry Dashboard"]
  D["beforeSend filter"] -- "library event" --> E["Send 100%"]
  D -- "third-party event" --> F["Sample 5%"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>request.js</strong><dd><code>Add Sentry reporting for WASM init failures with step tracking</code></dd></summary>
<hr>

packages/embed/src/js/request.js

<ul><li>Import <code>@sentry/browser</code> at the top of the file<br> <li> Add a <code>step</code> variable to track which phase of WASM init is executing <br>(fetch, integrity, instantiate)<br> <li> Add a <code>catch</code> block that calls <code>Sentry.captureException</code> with <code>area: </code><br><code>'wasm_init'</code> and <code>wasmStep</code> tags, then re-throws</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/611/files#diff-082025035f3eb04389450b92c1cfcf640a863fc3643a5940875dcd593115dcf0">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>script.js</strong><dd><code>Relax Sentry filter to sample third-party events at 5%</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/script.js

<ul><li>Replace the all-or-nothing <code>beforeSend</code> filter that dropped non-library <br>events<br> <li> Tag events with <code>source: 'library'</code> or <code>source: 'third-party-frame'</code><br> <li> Sample third-party events at 5% instead of dropping them entirely<br> <li> Add optional chaining for safer <code>frame.filename</code> access</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/611/files#diff-eacde2c20e43f17cb22a272a8901ba388a85865721a1dc121c2554a839d2ecc9">+21/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>