### PR TITLE
feat(embed): tag init-API failures + partner_id on iframe pages

### DIFF
--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -18,6 +18,10 @@ import {
   idInfoToIdSelection,
   applyIdInfoPrefill,
 } from './id-info-utils.js';
+import {
+  buildInitApiFailure,
+  captureInitApiFailure,
+} from './init-api-sentry.js';
 
 (function basicKyc() {
   'use strict';
@@ -130,32 +134,13 @@ import {
           generalConstraints: generalConstraints.hosted_web.basic_kyc,
         };
       }
-      const failedRequests = [];
-      if (!productsConfigResponse.ok) failedRequests.push('products_config');
-      if (!servicesResponse.ok) failedRequests.push('services');
-      initApiFailure = {
-        failedRequests,
-        productsConfigStatus: productsConfigResponse.status,
-        servicesStatus: servicesResponse.status,
-      };
+      initApiFailure = buildInitApiFailure(
+        productsConfigResponse,
+        servicesResponse,
+      );
       throw new Error('Failed to get supported ID types');
     } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          area: 'init_api',
-          failedRequest: initApiFailure
-            ? initApiFailure.failedRequests.join(',')
-            : 'rejection',
-          ...(initApiFailure
-            ? {
-                productsConfigStatus: String(
-                  initApiFailure.productsConfigStatus,
-                ),
-                servicesStatus: String(initApiFailure.servicesStatus),
-              }
-            : {}),
-        },
-      });
+      captureInitApiFailure(e, initApiFailure);
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }

--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import validate from 'validate.js';
 import '@smileid/web-components/combobox';
 import '@smileid/web-components/end-user-consent';
@@ -69,6 +70,11 @@ import {
   }
 
   async function getProductConstraints() {
+    // Captured at the point we know which response.ok was false so the catch
+    // below can attach response-level detail to the Sentry event. Null when
+    // the failure is a promise rejection (network drop, abort, etc.) rather
+    // than a non-OK HTTP response.
+    let initApiFailure = null;
     try {
       const productsConfigPayload = {
         partner_id: config.partner_details.partner_id,
@@ -124,8 +130,32 @@ import {
           generalConstraints: generalConstraints.hosted_web.basic_kyc,
         };
       }
+      const failedRequests = [];
+      if (!productsConfigResponse.ok) failedRequests.push('products_config');
+      if (!servicesResponse.ok) failedRequests.push('services');
+      initApiFailure = {
+        failedRequests,
+        productsConfigStatus: productsConfigResponse.status,
+        servicesStatus: servicesResponse.status,
+      };
       throw new Error('Failed to get supported ID types');
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: {
+          area: 'init_api',
+          failedRequest: initApiFailure
+            ? initApiFailure.failedRequests.join(',')
+            : 'rejection',
+          ...(initApiFailure
+            ? {
+                productsConfigStatus: String(
+                  initApiFailure.productsConfigStatus,
+                ),
+                servicesStatus: String(initApiFailure.servicesStatus),
+              }
+            : {}),
+        },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -152,6 +182,16 @@ import {
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        // Tag every Sentry event from this iframe context with partner_id and
+        // environment. The parent script.js tags the parent window's Sentry
+        // hub, but this iframe runs in its own JS context with its own hub —
+        // without these tags, errors from this page are unattributable.
+        if (config.partner_details?.partner_id) {
+          Sentry.setTag('partner_id', config.partner_details.partner_id);
+        }
+        if (config.environment) {
+          Sentry.setTag('environment', config.environment);
+        }
         await setCurrentLocale(config.translation?.language || 'en', {
           locales: config.translation?.locales,
         });

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -20,6 +20,10 @@ import {
   idInfoToIdSelection,
   applyIdInfoPrefill,
 } from './id-info-utils.js';
+import {
+  buildInitApiFailure,
+  captureInitApiFailure,
+} from './init-api-sentry.js';
 
 (function biometricKyc() {
   'use strict';
@@ -139,32 +143,13 @@ import {
           generalConstraints: generalConstraints.hosted_web.biometric_kyc,
         };
       }
-      const failedRequests = [];
-      if (!productsConfigResponse.ok) failedRequests.push('products_config');
-      if (!servicesResponse.ok) failedRequests.push('services');
-      initApiFailure = {
-        failedRequests,
-        productsConfigStatus: productsConfigResponse.status,
-        servicesStatus: servicesResponse.status,
-      };
+      initApiFailure = buildInitApiFailure(
+        productsConfigResponse,
+        servicesResponse,
+      );
       throw new Error('Failed to get supported ID types');
     } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          area: 'init_api',
-          failedRequest: initApiFailure
-            ? initApiFailure.failedRequests.join(',')
-            : 'rejection',
-          ...(initApiFailure
-            ? {
-                productsConfigStatus: String(
-                  initApiFailure.productsConfigStatus,
-                ),
-                servicesStatus: String(initApiFailure.servicesStatus),
-              }
-            : {}),
-        },
-      });
+      captureInitApiFailure(e, initApiFailure);
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import JSZip from 'jszip';
 import validate from 'validate.js';
 import '@smileid/web-components/end-user-consent';
@@ -81,6 +82,11 @@ import {
   }
 
   async function getProductConstraints() {
+    // Captured at the point we know which response.ok was false so the catch
+    // below can attach response-level detail to the Sentry event. Null when
+    // the failure is a promise rejection (network drop, abort, etc.) rather
+    // than a non-OK HTTP response.
+    let initApiFailure = null;
     try {
       const productsConfigPayload = {
         partner_id: config.partner_details.partner_id,
@@ -133,8 +139,32 @@ import {
           generalConstraints: generalConstraints.hosted_web.biometric_kyc,
         };
       }
+      const failedRequests = [];
+      if (!productsConfigResponse.ok) failedRequests.push('products_config');
+      if (!servicesResponse.ok) failedRequests.push('services');
+      initApiFailure = {
+        failedRequests,
+        productsConfigStatus: productsConfigResponse.status,
+        servicesStatus: servicesResponse.status,
+      };
       throw new Error('Failed to get supported ID types');
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: {
+          area: 'init_api',
+          failedRequest: initApiFailure
+            ? initApiFailure.failedRequests.join(',')
+            : 'rejection',
+          ...(initApiFailure
+            ? {
+                productsConfigStatus: String(
+                  initApiFailure.productsConfigStatus,
+                ),
+                servicesStatus: String(initApiFailure.servicesStatus),
+              }
+            : {}),
+        },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -161,6 +191,16 @@ import {
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        // Tag every Sentry event from this iframe context with partner_id and
+        // environment. The parent script.js tags the parent window's Sentry
+        // hub, but this iframe runs in its own JS context with its own hub —
+        // without these tags, errors from this page are unattributable.
+        if (config.partner_details?.partner_id) {
+          Sentry.setTag('partner_id', config.partner_details.partner_id);
+        }
+        if (config.environment) {
+          Sentry.setTag('environment', config.environment);
+        }
         await setCurrentLocale(config.translation?.language || 'en', {
           locales: config.translation?.locales,
         });

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import '@smileid/web-components/combobox';
 import '@smileid/web-components/smart-camera-web';
 import {
@@ -112,6 +113,9 @@ import {
 
       return json.valid_documents;
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: { area: 'init_api', failedRequest: 'valid_documents' },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -139,6 +143,9 @@ import {
 
       return json.hosted_web.doc_verification;
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: { area: 'init_api', failedRequest: 'services' },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -152,6 +159,16 @@ import {
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        // Tag every Sentry event from this iframe context with partner_id and
+        // environment. The parent script.js tags the parent window's Sentry
+        // hub, but this iframe runs in its own JS context with its own hub —
+        // without these tags, errors from this page are unattributable.
+        if (config.partner_details?.partner_id) {
+          Sentry.setTag('partner_id', config.partner_details.partner_id);
+        }
+        if (config.environment) {
+          Sentry.setTag('environment', config.environment);
+        }
         try {
           const language = config.translation?.language || 'en-GB';
           await setCurrentLocale(language, {

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -109,12 +109,25 @@ import {
 
     try {
       const response = await fetch(url.toString(), fetchConfig);
+      // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
+      // an HTTP failure here would parse JSON of an error body and silently
+      // return undefined without a Sentry event. Explicitly throw so the
+      // catch tags the request and the status before re-throwing.
+      if (!response.ok) {
+        const err = new Error('Failed to get supported ID types');
+        err.httpStatus = response.status;
+        throw err;
+      }
       const json = await response.json();
 
       return json.valid_documents;
     } catch (e) {
       Sentry.captureException(e, {
-        tags: { area: 'init_api', failedRequest: 'valid_documents' },
+        tags: {
+          area: 'init_api',
+          failedRequest: 'valid_documents',
+          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+        },
       });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
@@ -139,12 +152,21 @@ import {
 
     try {
       const response = await fetch(url.toString(), fetchConfig);
+      if (!response.ok) {
+        const err = new Error('Failed to get supported ID types');
+        err.httpStatus = response.status;
+        throw err;
+      }
       const json = await response.json();
 
       return json.hosted_web.doc_verification;
     } catch (e) {
       Sentry.captureException(e, {
-        tags: { area: 'init_api', failedRequest: 'services' },
+        tags: {
+          area: 'init_api',
+          failedRequest: 'services',
+          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+        },
       });
       throw new Error('Failed to get supported ID types', { cause: e });
     }

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import validate from 'validate.js';
 import '@smileid/web-components/combobox';
 import '@smileid/web-components/end-user-consent';
@@ -70,6 +71,11 @@ import {
   }
 
   async function getProductConstraints() {
+    // Captured at the point we know which response.ok was false so the catch
+    // below can attach response-level detail to the Sentry event. Null when
+    // the failure is a promise rejection (network drop, abort, etc.) rather
+    // than a non-OK HTTP response.
+    let initApiFailure = null;
     try {
       const productsConfigPayload = {
         partner_id: config.partner_details.partner_id,
@@ -123,8 +129,32 @@ import {
           generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
         };
       }
+      const failedRequests = [];
+      if (!productsConfigResponse.ok) failedRequests.push('products_config');
+      if (!servicesResponse.ok) failedRequests.push('services');
+      initApiFailure = {
+        failedRequests,
+        productsConfigStatus: productsConfigResponse.status,
+        servicesStatus: servicesResponse.status,
+      };
       throw new Error('Failed to get supported ID types');
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: {
+          area: 'init_api',
+          failedRequest: initApiFailure
+            ? initApiFailure.failedRequests.join(',')
+            : 'rejection',
+          ...(initApiFailure
+            ? {
+                productsConfigStatus: String(
+                  initApiFailure.productsConfigStatus,
+                ),
+                servicesStatus: String(initApiFailure.servicesStatus),
+              }
+            : {}),
+        },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -151,6 +181,16 @@ import {
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        // Tag every Sentry event from this iframe context with partner_id and
+        // environment. The parent script.js tags the parent window's Sentry
+        // hub, but this iframe runs in its own JS context with its own hub —
+        // without these tags, errors from this page are unattributable.
+        if (config.partner_details?.partner_id) {
+          Sentry.setTag('partner_id', config.partner_details.partner_id);
+        }
+        if (config.environment) {
+          Sentry.setTag('environment', config.environment);
+        }
         await setCurrentLocale(config.translation?.language || 'en', {
           locales: config.translation?.locales,
         });

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -18,6 +18,10 @@ import {
   idInfoToIdSelection,
   applyIdInfoPrefill,
 } from './id-info-utils.js';
+import {
+  buildInitApiFailure,
+  captureInitApiFailure,
+} from './init-api-sentry.js';
 
 (function eKYC() {
   'use strict';
@@ -129,32 +133,13 @@ import {
           generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
         };
       }
-      const failedRequests = [];
-      if (!productsConfigResponse.ok) failedRequests.push('products_config');
-      if (!servicesResponse.ok) failedRequests.push('services');
-      initApiFailure = {
-        failedRequests,
-        productsConfigStatus: productsConfigResponse.status,
-        servicesStatus: servicesResponse.status,
-      };
+      initApiFailure = buildInitApiFailure(
+        productsConfigResponse,
+        servicesResponse,
+      );
       throw new Error('Failed to get supported ID types');
     } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          area: 'init_api',
-          failedRequest: initApiFailure
-            ? initApiFailure.failedRequests.join(',')
-            : 'rejection',
-          ...(initApiFailure
-            ? {
-                productsConfigStatus: String(
-                  initApiFailure.productsConfigStatus,
-                ),
-                servicesStatus: String(initApiFailure.servicesStatus),
-              }
-            : {}),
-        },
-      });
+      captureInitApiFailure(e, initApiFailure);
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }

--- a/packages/embed/src/js/enhanced-document-verification.js
+++ b/packages/embed/src/js/enhanced-document-verification.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import JSZip from 'jszip';
 import '@smileid/web-components/smart-camera-web';
 import {
@@ -86,6 +87,9 @@ function applyPageTranslations() {
 
       return json.hosted_web.enhanced_document_verification;
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: { area: 'init_api', failedRequest: 'services' },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -99,6 +103,16 @@ function applyPageTranslations() {
         event.data.includes('SmileIdentity::Configuration')
       ) {
         config = JSON.parse(event.data);
+        // Tag every Sentry event from this iframe context with partner_id and
+        // environment. The parent script.js tags the parent window's Sentry
+        // hub, but this iframe runs in its own JS context with its own hub —
+        // without these tags, errors from this page are unattributable.
+        if (config.partner_details?.partner_id) {
+          Sentry.setTag('partner_id', config.partner_details.partner_id);
+        }
+        if (config.environment) {
+          Sentry.setTag('environment', config.environment);
+        }
         await setCurrentLocale(config.translation?.language || 'en', {
           locales: config.translation?.locales,
         });

--- a/packages/embed/src/js/enhanced-document-verification.js
+++ b/packages/embed/src/js/enhanced-document-verification.js
@@ -83,12 +83,25 @@ function applyPageTranslations() {
 
     try {
       const response = await fetch(url.toString());
+      // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
+      // an HTTP failure here would parse JSON of an error body and silently
+      // return undefined without a Sentry event. Explicitly throw so the
+      // catch tags the request and the status before re-throwing.
+      if (!response.ok) {
+        const err = new Error('Failed to get supported ID types');
+        err.httpStatus = response.status;
+        throw err;
+      }
       const json = await response.json();
 
       return json.hosted_web.enhanced_document_verification;
     } catch (e) {
       Sentry.captureException(e, {
-        tags: { area: 'init_api', failedRequest: 'services' },
+        tags: {
+          area: 'init_api',
+          failedRequest: 'services',
+          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+        },
       });
       throw new Error('Failed to get supported ID types', { cause: e });
     }

--- a/packages/embed/src/js/init-api-sentry.js
+++ b/packages/embed/src/js/init-api-sentry.js
@@ -1,0 +1,34 @@
+import * as Sentry from '@sentry/browser';
+
+// Build a failure descriptor when both `products_config` and `services`
+// responses arrived from a Promise.all but at least one was non-OK. Pass
+// the result via the closure-local `initApiFailure` variable so the catch
+// can attach response-level detail to the Sentry event.
+export function buildInitApiFailure(productsConfigResponse, servicesResponse) {
+  const failedRequests = [];
+  if (!productsConfigResponse.ok) failedRequests.push('products_config');
+  if (!servicesResponse.ok) failedRequests.push('services');
+  return {
+    failedRequests,
+    productsConfigStatus: productsConfigResponse.status,
+    servicesStatus: servicesResponse.status,
+  };
+}
+
+// Report an init-API failure to Sentry. `failure` is the descriptor from
+// `buildInitApiFailure` if both responses arrived (one of them non-OK), or
+// `null` if the underlying fetch rejected (network drop, abort, etc.).
+export function captureInitApiFailure(e, failure) {
+  Sentry.captureException(e, {
+    tags: {
+      area: 'init_api',
+      failedRequest: failure ? failure.failedRequests.join(',') : 'rejection',
+      ...(failure
+        ? {
+            productsConfigStatus: String(failure.productsConfigStatus),
+            servicesStatus: String(failure.servicesStatus),
+          }
+        : {}),
+    },
+  });
+}

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -76,12 +76,25 @@ import * as Sentry from '@sentry/browser';
 
     try {
       const response = await fetch(url.toString(), fetchConfig);
+      // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
+      // an HTTP failure here would parse JSON of an error body and silently
+      // return undefined without a Sentry event. Explicitly throw so the
+      // catch tags the request and the status before re-throwing.
+      if (!response.ok) {
+        const err = new Error('Failed to get supported ID types');
+        err.httpStatus = response.status;
+        throw err;
+      }
       const json = await response.json();
 
       return json.valid_documents;
     } catch (e) {
       Sentry.captureException(e, {
-        tags: { area: 'init_api', failedRequest: 'valid_documents' },
+        tags: {
+          area: 'init_api',
+          failedRequest: 'valid_documents',
+          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+        },
       });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
@@ -108,12 +121,21 @@ import * as Sentry from '@sentry/browser';
 
     try {
       const response = await fetch(url.toString(), fetchConfig);
+      if (!response.ok) {
+        const err = new Error('Failed to get supported ID types');
+        err.httpStatus = response.status;
+        throw err;
+      }
       const json = await response.json();
 
       return json.hosted_web;
     } catch (e) {
       Sentry.captureException(e, {
-        tags: { area: 'init_api', failedRequest: 'services' },
+        tags: {
+          area: 'init_api',
+          failedRequest: 'services',
+          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+        },
       });
       throw new Error('Failed to get supported ID types', { cause: e });
     }

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/browser';
+
 (function productSelection() {
   'use strict';
 
@@ -78,6 +80,9 @@
 
       return json.valid_documents;
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: { area: 'init_api', failedRequest: 'valid_documents' },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -107,6 +112,9 @@
 
       return json.hosted_web;
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: { area: 'init_api', failedRequest: 'services' },
+      });
       throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
@@ -355,6 +363,17 @@
       ) {
         if (event.data.includes('SmileIdentity::Configuration')) {
           config = JSON.parse(event.data);
+          // Tag every Sentry event from this iframe context with partner_id
+          // and environment. The parent script.js tags the parent window's
+          // Sentry hub, but this iframe runs in its own JS context with its
+          // own hub — without these tags, errors from this page are
+          // unattributable.
+          if (config.partner_details?.partner_id) {
+            Sentry.setTag('partner_id', config.partner_details.partner_id);
+          }
+          if (config.environment) {
+            Sentry.setTag('environment', config.environment);
+          }
 
           LoadingScreen.querySelector('.credits').hidden =
             config.hide_attribution;


### PR DESCRIPTION
### **User description**
## Summary

Two related observability gaps in the product-entry iframe pages, addressed together because they touch the same six files:

### Gap 1 — "Failed to get supported ID types" is mis-labeled

Three of the six iframe pages (`biometric-kyc.js`, `ekyc.js`, `basic-kyc.js`) wrap two requests in a `Promise.all`:
- `/products_config` (POST, signed via WASM in `request.js`)
- `/services` (GET, no auth)

…then throw a single generic \`Error('Failed to get supported ID types')\` if either fails. The other three (`doc-verification.js`, `enhanced-document-verification.js`, `product-selection.js`) wrap a single fetch with the same generic error.

The error message points at `/services` regardless of which request actually failed. In Sentry this manifests as six issue variants (`WEB-CLIENT-4S` / `2W` / `9F` / `6K` / `P0` / `5K`), **~6,500 events combined, ~99% iPhone**, with no way to slice by which call actually failed.

This PR adds `Sentry.captureException` inside each catch, tagged with:
- `area: 'init_api'`
- `failedRequest`: one of `products_config`, `services`, `valid_documents`, `products_config,services`, or `rejection`
- `productsConfigStatus` / `servicesStatus` (status codes) where both responses were received but at least one was non-OK

The thrown error and its message are unchanged — downstream consumers see exactly the same behavior. Pure additive instrumentation.

For the three files using `Promise.all`, the pattern uses a closure-local `initApiFailure` variable so the single `Sentry.captureException` in the catch picks up response-level detail when both promises resolved, or tags `failedRequest:rejection` when a promise rejected.

### Gap 2 — `partner_id` and `environment` tags are missing on iframe pages

`script.js` sets `Sentry.setTag('partner_id', ...)` on the **parent window's** Sentry hub when `isConfigValid` runs. But the iframes (`biometric-kyc.html` et al) load in their own JS context with their own Sentry hub. Errors from the iframe context have no partner attribution today, making it impossible to answer "show me all errors HappyPay users hit this week" in Sentry.

This PR sets `Sentry.setTag('partner_id', ...)` and `Sentry.setTag('environment', ...)` on every iframe page immediately after the postMessage'd config is parsed. Both tags are guarded with optional chaining and only fire when the values are present.

## Files touched

All in `packages/embed/src/js/`:
- `biometric-kyc.js`
- `ekyc.js`
- `basic-kyc.js`
- `doc-verification.js`
- `enhanced-document-verification.js`
- `product-selection.js`

`product-selection.js` previously had no top-level imports (IIFE-only). Added the `Sentry` import at the very top, consistent with how esbuild bundles each entry point.

## Risk

Low. Observability-only — no behavior change, no API surface change, no thrown-error message change. The `captureException` calls are guarded by the existing try/catch boundaries; the `setTag` calls are no-ops when the fields are absent.

## Test plan

- [x] Lint scoped to changed files: my branch and `main` show identical lint counts on every file (verified by stashing and re-linting). All remaining lint warnings are pre-existing on `main` and unrelated to this change.
- [x] Prettier: `npx prettier --check` passes on all six files.
- [ ] Manual: in dev, return a 4xx from `/products_config` only → confirm Sentry event tagged `failedRequest: products_config` with the right `productsConfigStatus`.
- [ ] Manual: return 4xx from both → confirm `failedRequest: products_config,services`.
- [ ] Manual: kill network during fetch → confirm `failedRequest: rejection`.
- [ ] Manual: trigger any error from inside the iframe → confirm Sentry event tagged with `partner_id` and `environment`.

## PR series

This is **PR 3 of 3** closing observability gaps surfaced by an investigation into customer-reported "users hit KYC capture screen, no callback received" failures.

- **PR 1** (#610) — `feat(smart-camera-web): report camera-init failures to Sentry`
- **PR 2** (#611) — `feat(embed): report WASM init failures + tag third-party events in Sentry`
- **PR 3** (this one) — per-product API failure tagging + iframe partner_id attribution

After all three merge and ship, we should see (within ~24h):
- Real iOS Safari camera-permission failures captured (silent today)
- Real WASM-compile failures attributable by `wasmStep` and `partner_id` (orphaned today)
- The actual `/products_config` vs `/services` failure split (collapsed under a single generic error today)
- Partner-level slicing across every error type from iframe pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Tag init-API failures with specific request attribution in Sentry

- Set `partner_id` and `environment` tags on iframe Sentry contexts

- Distinguish `products_config` vs `services` vs `valid_documents` failures

- Apply consistent pattern across all six product-entry iframe pages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["iframe postMessage received"] -- "config parsed" --> B["Sentry.setTag partner_id, environment"]
  C["getProductConstraints / fetch"] -- "catch error" --> D["Sentry.captureException"]
  D -- "tags: area, failedRequest, status" --> E["Sentry Dashboard"]
  B --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>basic-kyc.js</strong><dd><code>Add Sentry attribution for init-API failures and partner context</code></dd></summary>
<hr>

packages/embed/src/js/basic-kyc.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>initApiFailure</code> tracking to identify which API call failed <br>(products_config, services, or both)<br> <li> Add <code>Sentry.captureException</code> in catch with <code>area: 'init_api'</code> and <br>response status tags<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-9fc764bf162b22278c4700f1a9c471e7edf5a0751f640a85b2a8f49d8f8b1155">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>biometric-kyc.js</strong><dd><code>Add Sentry attribution for init-API failures and partner context</code></dd></summary>
<hr>

packages/embed/src/js/biometric-kyc.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>initApiFailure</code> tracking to identify which API call failed <br>(products_config, services, or both)<br> <li> Add <code>Sentry.captureException</code> in catch with <code>area: 'init_api'</code> and <br>response status tags<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-f5be2e469a49bbd0cbecc5c18f86fd8c6b3ece0d894267283f0302b4c905f50d">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>doc-verification.js</strong><dd><code>Add Sentry attribution for doc-verification API failures</code>&nbsp; </dd></summary>
<hr>

packages/embed/src/js/doc-verification.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>Sentry.captureException</code> in catch blocks for <code>valid_documents</code> and <br><code>services</code> fetches<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-ac98d8d890cb7e0009aba6a97be503a146e059f2ea0d1add65f9bca878fa5cff">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ekyc.js</strong><dd><code>Add Sentry attribution for eKYC init-API failures and partner context</code></dd></summary>
<hr>

packages/embed/src/js/ekyc.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>initApiFailure</code> tracking to identify which API call failed <br>(products_config, services, or both)<br> <li> Add <code>Sentry.captureException</code> in catch with <code>area: 'init_api'</code> and <br>response status tags<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-d96aafd656e4402106db69c724ad7415e0f6e30206c85c90f345c49ec7a5ec2a">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification.js</strong><dd><code>Add Sentry attribution for enhanced doc-verification failures</code></dd></summary>
<hr>

packages/embed/src/js/enhanced-document-verification.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>Sentry.captureException</code> in catch block for <code>services</code> fetch with <br><code>area: 'init_api'</code> tag<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-ebd071140290922ac1d9cb1d1faec8f1e0f100f965490c81a28efc589e871911">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>product-selection.js</strong><dd><code>Add Sentry attribution for product-selection API failures</code></dd></summary>
<hr>

packages/embed/src/js/product-selection.js

<ul><li>Import <code>@sentry/browser</code><br> <li> Add <code>Sentry.captureException</code> in catch blocks for <code>valid_documents</code> and <br><code>services</code> fetches<br> <li> Set <code>partner_id</code> and <code>environment</code> Sentry tags when config is received via <br>postMessage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/612/files#diff-ea4f545f0962c77d66b029aee2825c0fd95bffcb15326d65e0483d6c53bc954a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>