### PR TITLE
chore: release 11.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.4.1] - 2026-05-18
+## [11.4.2] - 2026-05-18
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "description": "A collection of SmileID browser clients and components",
   "main": "index.js",
   "private": true,

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/embed",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "description": "Self Hosted Integration for Smile Identity on the Web",
   "private": true,
   "main": "inline.js",

--- a/packages/smart-camera-web/package.json
+++ b/packages/smart-camera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smile_identity/smart-camera-web",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "description": "WebComponent for smartly capturing images on the web, for use with SmileIdentity",
   "main": "smart-camera-web.js",
   "scripts": {

--- a/packages/web-components/lib/components/signature-pad/package.json
+++ b/packages/web-components/lib/components/signature-pad/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smileid/signature-pad",
-  "version": "11.4.1",
-  "private": "true",
+  "version": "11.4.2",
+  "private": true,
   "exports": {
     ".": "./index.js"
   },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smileid/web-components",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "private": false,
   "main": "dist/esm/main.js",
   "module": "dist/esm/main.js",


### PR DESCRIPTION
## Release 11.4.2

Bumps all package versions from `11.4.1` to `11.4.2` and updates the changelog.

Supersedes #615.

### Changelog

#### Added
- Improve error reporting
- Add new document capture instructions with an opt-in option to use the new design

#### Fixed
- Fixed combobox filtering on Huawei devices by using the `input` event
