### PR TITLE
fix(embed): add fetch retry + timeout for iOS Safari init-API failures

### DIFF
--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -73,75 +73,105 @@ import {
     });
   }
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
-    // Captured at the point we know which response.ok was false so the catch
-    // below can attach response-level detail to the Sentry event. Null when
-    // the failure is a promise rejection (network drop, abort, etc.) rather
-    // than a non-OK HTTP response.
-    let initApiFailure = null;
-    try {
-      const productsConfigPayload = {
-        partner_id: config.partner_details.partner_id,
-        token: config.token,
-        partner_params,
-      };
+    // iOS Safari (especially iOS 18+) intermittently fails with
+    // "TypeError: Load failed" — a transient network-level error that almost
+    // always succeeds on retry. Retry up to 2 times (3 total attempts) with
+    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // deterministic and are never retried.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      // Captured at the point we know which response.ok was false so the catch
+      // below can attach response-level detail to the Sentry event. Null when
+      // the failure is a promise rejection (network drop, abort, etc.) rather
+      // than a non-OK HTTP response.
+      let initApiFailure = null;
+      try {
+        const productsConfigPayload = {
+          partner_id: config.partner_details.partner_id,
+          token: config.token,
+          partner_params,
+        };
 
-      const productsConfigUrl = `${getEndpoint(
-        config.environment,
-      )}/v1/products_config`;
-      const productsConfigPromise = postData(
-        productsConfigUrl,
-        productsConfigPayload,
-      );
-      const locale = getCurrentLocale();
-      const servicesUrl = new URL(
-        `${getEndpoint(config.environment)}/v1/services`,
-      );
-      if (locale) {
-        servicesUrl.searchParams.append('locale', locale);
-      }
-      const servicesPromise = fetch(servicesUrl.toString());
-      const [productsConfigResponse, servicesResponse] = await Promise.all([
-        productsConfigPromise,
-        servicesPromise,
-      ]);
+        const productsConfigUrl = `${getEndpoint(
+          config.environment,
+        )}/v1/products_config`;
+        const productsConfigPromise = postData(
+          productsConfigUrl,
+          productsConfigPayload,
+        );
+        const locale = getCurrentLocale();
+        const servicesUrl = new URL(
+          `${getEndpoint(config.environment)}/v1/services`,
+        );
+        if (locale) {
+          servicesUrl.searchParams.append('locale', locale);
+        }
+        const servicesPromise = fetchWithTimeout(
+          servicesUrl.toString(),
+          {},
+          10000,
+        );
+        const [productsConfigResponse, servicesResponse] = await Promise.all([
+          productsConfigPromise,
+          servicesPromise,
+        ]);
 
-      if (productsConfigResponse.ok && servicesResponse.ok) {
-        const partnerConstraints = await productsConfigResponse.json();
-        const generalConstraints = await servicesResponse.json();
-        ngBankCodes = generalConstraints.bank_codes;
+        if (productsConfigResponse.ok && servicesResponse.ok) {
+          const partnerConstraints = await productsConfigResponse.json();
+          const generalConstraints = await servicesResponse.json();
+          ngBankCodes = generalConstraints.bank_codes;
 
-        const previewBvnMfa = config.previewBVNMFA;
-        if (previewBvnMfa) {
-          generalConstraints.hosted_web.basic_kyc.NG.id_types.BVN_MFA = {
-            id_number_regex: '^[0-9]{11}$',
-            label: 'Bank Verification Number (with OTP)',
-            required_fields: [
-              'country',
-              'id_type',
-              'session_id',
-              'user_id',
-              'job_id',
-              'first_name',
-              'last_name',
-            ],
-            test_data: '00000000000',
+          const previewBvnMfa = config.previewBVNMFA;
+          if (previewBvnMfa) {
+            generalConstraints.hosted_web.basic_kyc.NG.id_types.BVN_MFA = {
+              id_number_regex: '^[0-9]{11}$',
+              label: 'Bank Verification Number (with OTP)',
+              required_fields: [
+                'country',
+                'id_type',
+                'session_id',
+                'user_id',
+                'job_id',
+                'first_name',
+                'last_name',
+              ],
+              test_data: '00000000000',
+            };
+          }
+
+          return {
+            partnerConstraints,
+            generalConstraints: generalConstraints.hosted_web.basic_kyc,
           };
         }
-
-        return {
-          partnerConstraints,
-          generalConstraints: generalConstraints.hosted_web.basic_kyc,
-        };
+        initApiFailure = buildInitApiFailure(
+          productsConfigResponse,
+          servicesResponse,
+        );
+        throw new Error('Failed to get supported ID types');
+      } catch (e) {
+        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        const isNetworkError =
+          initApiFailure === null &&
+          (e instanceof TypeError || e.name === 'AbortError');
+        if (!isNetworkError || attempt === MAX_ATTEMPTS) {
+          captureInitApiFailure(e, initApiFailure);
+          throw new Error('Failed to get supported ID types', { cause: e });
+        }
+        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
-      initApiFailure = buildInitApiFailure(
-        productsConfigResponse,
-        servicesResponse,
-      );
-      throw new Error('Failed to get supported ID types');
-    } catch (e) {
-      captureInitApiFailure(e, initApiFailure);
-      throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
 
@@ -194,10 +224,17 @@ import {
         activeScreen = LoadingScreen;
 
         getPartnerParams();
-        const { partnerConstraints, generalConstraints } =
-          await getProductConstraints();
-        productConstraints = generalConstraints;
-        initializeSession(generalConstraints, partnerConstraints);
+        try {
+          const { partnerConstraints, generalConstraints } =
+            await getProductConstraints();
+          productConstraints = generalConstraints;
+          initializeSession(generalConstraints, partnerConstraints);
+        } catch (e) {
+          (referenceWindow.parent || referenceWindow).postMessage(
+            'SmileIdentity::Error',
+            '*',
+          );
+        }
       }
     },
     false,

--- a/packages/embed/src/js/basic-kyc.js
+++ b/packages/embed/src/js/basic-kyc.js
@@ -22,6 +22,7 @@ import {
   buildInitApiFailure,
   captureInitApiFailure,
 } from './init-api-sentry.js';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 (function basicKyc() {
   'use strict';
@@ -59,27 +60,21 @@ import {
   const CloseIframeButtons = document.querySelectorAll('.close-iframe');
 
   async function postData(url = '', data = {}, shouldSignPayload = false) {
-    return fetch(url, {
-      method: 'POST',
-      mode: 'cors',
-      cache: 'no-cache',
-      headers: {
-        ...(shouldSignPayload &&
-          (await getHeaders(data, config.partner_details.partner_id))),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
+    return fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        mode: 'cors',
+        cache: 'no-cache',
+        headers: {
+          ...(shouldSignPayload &&
+            (await getHeaders(data, config.partner_details.partner_id))),
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
       },
-      body: JSON.stringify(data),
-    });
-  }
-
-  // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
+      10000,
     );
   }
 
@@ -87,9 +82,13 @@ import {
     // iOS Safari (especially iOS 18+) intermittently fails with
     // "TypeError: Load failed" — a transient network-level error that almost
     // always succeeds on retry. Retry up to 2 times (3 total attempts) with
-    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // linear backoff (1 s, 2 s). HTTP failures (initApiFailure !== null) are
     // deterministic and are never retried.
     const MAX_ATTEMPTS = 3;
+    // Reason: cache the parsed products_config across attempts so a transient
+    // /services failure doesn't re-issue the (possibly side-effecting)
+    // /products_config POST that already succeeded.
+    let cachedPartnerConstraints = null;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       // Captured at the point we know which response.ok was false so the catch
       // below can attach response-level detail to the Sentry event. Null when
@@ -106,10 +105,6 @@ import {
         const productsConfigUrl = `${getEndpoint(
           config.environment,
         )}/v1/products_config`;
-        const productsConfigPromise = postData(
-          productsConfigUrl,
-          productsConfigPayload,
-        );
         const locale = getCurrentLocale();
         const servicesUrl = new URL(
           `${getEndpoint(config.environment)}/v1/services`,
@@ -117,59 +112,85 @@ import {
         if (locale) {
           servicesUrl.searchParams.append('locale', locale);
         }
-        const servicesPromise = fetchWithTimeout(
-          servicesUrl.toString(),
-          {},
-          10000,
-        );
-        const [productsConfigResponse, servicesResponse] = await Promise.all([
-          productsConfigPromise,
-          servicesPromise,
-        ]);
 
-        if (productsConfigResponse.ok && servicesResponse.ok) {
-          const partnerConstraints = await productsConfigResponse.json();
-          const generalConstraints = await servicesResponse.json();
-          ngBankCodes = generalConstraints.bank_codes;
-
-          const previewBvnMfa = config.previewBVNMFA;
-          if (previewBvnMfa) {
-            generalConstraints.hosted_web.basic_kyc.NG.id_types.BVN_MFA = {
-              id_number_regex: '^[0-9]{11}$',
-              label: 'Bank Verification Number (with OTP)',
-              required_fields: [
-                'country',
-                'id_type',
-                'session_id',
-                'user_id',
-                'job_id',
-                'first_name',
-                'last_name',
-              ],
-              test_data: '00000000000',
+        let partnerConstraints;
+        let servicesResponse;
+        if (cachedPartnerConstraints) {
+          partnerConstraints = cachedPartnerConstraints;
+          servicesResponse = await fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          if (!servicesResponse.ok) {
+            initApiFailure = {
+              failedRequests: ['services'],
+              productsConfigStatus: 200,
+              servicesStatus: servicesResponse.status,
             };
+            throw new Error('Failed to get supported ID types');
           }
+        } else {
+          const productsConfigPromise = postData(
+            productsConfigUrl,
+            productsConfigPayload,
+          );
+          const servicesPromise = fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          const [productsConfigResponse, servicesResp] = await Promise.all([
+            productsConfigPromise,
+            servicesPromise,
+          ]);
+          servicesResponse = servicesResp;
+          if (!productsConfigResponse.ok || !servicesResponse.ok) {
+            initApiFailure = buildInitApiFailure(
+              productsConfigResponse,
+              servicesResponse,
+            );
+            throw new Error('Failed to get supported ID types');
+          }
+          partnerConstraints = await productsConfigResponse.json();
+          cachedPartnerConstraints = partnerConstraints;
+        }
+        const generalConstraints = await servicesResponse.json();
+        ngBankCodes = generalConstraints.bank_codes;
 
-          return {
-            partnerConstraints,
-            generalConstraints: generalConstraints.hosted_web.basic_kyc,
+        const previewBvnMfa = config.previewBVNMFA;
+        if (previewBvnMfa) {
+          generalConstraints.hosted_web.basic_kyc.NG.id_types.BVN_MFA = {
+            id_number_regex: '^[0-9]{11}$',
+            label: 'Bank Verification Number (with OTP)',
+            required_fields: [
+              'country',
+              'id_type',
+              'session_id',
+              'user_id',
+              'job_id',
+              'first_name',
+              'last_name',
+            ],
+            test_data: '00000000000',
           };
         }
-        initApiFailure = buildInitApiFailure(
-          productsConfigResponse,
-          servicesResponse,
-        );
-        throw new Error('Failed to get supported ID types');
+
+        return {
+          partnerConstraints,
+          generalConstraints: generalConstraints.hosted_web.basic_kyc,
+        };
       } catch (e) {
-        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        // HTTP failures have initApiFailure !== null — deterministic, never
+        // retry. Network-level failures are tagged by `fetchWithTimeout` with
+        // `.isNetworkError = true`.
         const isNetworkError =
-          initApiFailure === null &&
-          (e instanceof TypeError || e.name === 'AbortError');
+          initApiFailure === null && e && e.isNetworkError === true;
         if (!isNetworkError || attempt === MAX_ATTEMPTS) {
           captureInitApiFailure(e, initApiFailure);
           throw new Error('Failed to get supported ID types', { cause: e });
         }
-        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        // Linear backoff: 1 s, then 2 s before the third attempt.
         await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
     }

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -90,72 +90,102 @@ window.Sentry = Sentry;
     });
   }
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
-    // Captured at the point we know which response.ok was false so the catch
-    // below can attach response-level detail to the Sentry event. Null when
-    // the failure is a promise rejection (network drop, abort, etc.) rather
-    // than a non-OK HTTP response.
-    let initApiFailure = null;
-    try {
-      const productsConfigPayload = {
-        partner_id: config.partner_details.partner_id,
-        token: config.token,
-        partner_params,
-      };
+    // iOS Safari (especially iOS 18+) intermittently fails with
+    // "TypeError: Load failed" — a transient network-level error that almost
+    // always succeeds on retry. Retry up to 2 times (3 total attempts) with
+    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // deterministic and are never retried.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      // Captured at the point we know which response.ok was false so the catch
+      // below can attach response-level detail to the Sentry event. Null when
+      // the failure is a promise rejection (network drop, abort, etc.) rather
+      // than a non-OK HTTP response.
+      let initApiFailure = null;
+      try {
+        const productsConfigPayload = {
+          partner_id: config.partner_details.partner_id,
+          token: config.token,
+          partner_params,
+        };
 
-      const productsConfigUrl = `${getEndpoint(
-        config.environment,
-      )}/products_config`;
-      const productsConfigPromise = postData(
-        productsConfigUrl,
-        productsConfigPayload,
-      );
-      const locale = getCurrentLocale();
-      const servicesUrl = new URL(
-        `${getEndpoint(config.environment)}/services`,
-      );
-      if (locale) {
-        servicesUrl.searchParams.append('locale', locale);
-      }
-      const servicesPromise = fetch(servicesUrl.toString());
-      const [productsConfigResponse, servicesResponse] = await Promise.all([
-        productsConfigPromise,
-        servicesPromise,
-      ]);
+        const productsConfigUrl = `${getEndpoint(
+          config.environment,
+        )}/products_config`;
+        const productsConfigPromise = postData(
+          productsConfigUrl,
+          productsConfigPayload,
+        );
+        const locale = getCurrentLocale();
+        const servicesUrl = new URL(
+          `${getEndpoint(config.environment)}/services`,
+        );
+        if (locale) {
+          servicesUrl.searchParams.append('locale', locale);
+        }
+        const servicesPromise = fetchWithTimeout(
+          servicesUrl.toString(),
+          {},
+          10000,
+        );
+        const [productsConfigResponse, servicesResponse] = await Promise.all([
+          productsConfigPromise,
+          servicesPromise,
+        ]);
 
-      if (productsConfigResponse.ok && servicesResponse.ok) {
-        const partnerConstraints = await productsConfigResponse.json();
-        const generalConstraints = await servicesResponse.json();
+        if (productsConfigResponse.ok && servicesResponse.ok) {
+          const partnerConstraints = await productsConfigResponse.json();
+          const generalConstraints = await servicesResponse.json();
 
-        const previewBvnMfa = config.previewBVNMFA;
-        if (previewBvnMfa) {
-          generalConstraints.hosted_web.biometric_kyc.NG.id_types.BVN_MFA = {
-            id_number_regex: '^[0-9]{11}$',
-            label: 'Bank Verification Number (with OTP)',
-            required_fields: [
-              'country',
-              'id_type',
-              'session_id',
-              'user_id',
-              'job_id',
-            ],
-            test_data: '00000000000',
+          const previewBvnMfa = config.previewBVNMFA;
+          if (previewBvnMfa) {
+            generalConstraints.hosted_web.biometric_kyc.NG.id_types.BVN_MFA = {
+              id_number_regex: '^[0-9]{11}$',
+              label: 'Bank Verification Number (with OTP)',
+              required_fields: [
+                'country',
+                'id_type',
+                'session_id',
+                'user_id',
+                'job_id',
+              ],
+              test_data: '00000000000',
+            };
+          }
+
+          return {
+            partnerConstraints,
+            generalConstraints: generalConstraints.hosted_web.biometric_kyc,
           };
         }
-
-        return {
-          partnerConstraints,
-          generalConstraints: generalConstraints.hosted_web.biometric_kyc,
-        };
+        initApiFailure = buildInitApiFailure(
+          productsConfigResponse,
+          servicesResponse,
+        );
+        throw new Error('Failed to get supported ID types');
+      } catch (e) {
+        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        const isNetworkError =
+          initApiFailure === null &&
+          (e instanceof TypeError || e.name === 'AbortError');
+        if (!isNetworkError || attempt === MAX_ATTEMPTS) {
+          captureInitApiFailure(e, initApiFailure);
+          throw new Error('Failed to get supported ID types', { cause: e });
+        }
+        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
-      initApiFailure = buildInitApiFailure(
-        productsConfigResponse,
-        servicesResponse,
-      );
-      throw new Error('Failed to get supported ID types');
-    } catch (e) {
-      captureInitApiFailure(e, initApiFailure);
-      throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
 
@@ -208,10 +238,17 @@ window.Sentry = Sentry;
         activeScreen = LoadingScreen;
 
         getPartnerParams();
-        const { partnerConstraints, generalConstraints } =
-          await getProductConstraints();
-        productConstraints = generalConstraints;
-        initializeSession(generalConstraints, partnerConstraints);
+        try {
+          const { partnerConstraints, generalConstraints } =
+            await getProductConstraints();
+          productConstraints = generalConstraints;
+          initializeSession(generalConstraints, partnerConstraints);
+        } catch (e) {
+          (referenceWindow.parent || referenceWindow).postMessage(
+            'SmileIdentity::Error',
+            '*',
+          );
+        }
       }
     },
     false,

--- a/packages/embed/src/js/biometric-kyc.js
+++ b/packages/embed/src/js/biometric-kyc.js
@@ -24,6 +24,7 @@ import {
   buildInitApiFailure,
   captureInitApiFailure,
 } from './init-api-sentry.js';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 // Expose Sentry on the iframe window so the standalone `smart-camera-web`
 // web component (which has no @sentry/browser dep of its own) can report
@@ -76,27 +77,21 @@ window.Sentry = Sentry;
   let skipInputScreen = false;
 
   async function postData(url = '', data = {}, shouldSignPayload = false) {
-    return fetch(url, {
-      method: 'POST',
-      mode: 'cors',
-      cache: 'no-cache',
-      headers: {
-        ...(shouldSignPayload &&
-          (await getHeaders(data, config.partner_details.partner_id))),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
+    return fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        mode: 'cors',
+        cache: 'no-cache',
+        headers: {
+          ...(shouldSignPayload &&
+            (await getHeaders(data, config.partner_details.partner_id))),
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
       },
-      body: JSON.stringify(data),
-    });
-  }
-
-  // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
+      10000,
     );
   }
 
@@ -104,9 +99,13 @@ window.Sentry = Sentry;
     // iOS Safari (especially iOS 18+) intermittently fails with
     // "TypeError: Load failed" — a transient network-level error that almost
     // always succeeds on retry. Retry up to 2 times (3 total attempts) with
-    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // linear backoff (1 s, 2 s). HTTP failures (initApiFailure !== null) are
     // deterministic and are never retried.
     const MAX_ATTEMPTS = 3;
+    // Reason: cache the parsed products_config across attempts so a transient
+    // /services failure doesn't re-issue the (possibly side-effecting)
+    // /products_config POST that already succeeded.
+    let cachedPartnerConstraints = null;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       // Captured at the point we know which response.ok was false so the catch
       // below can attach response-level detail to the Sentry event. Null when
@@ -123,10 +122,6 @@ window.Sentry = Sentry;
         const productsConfigUrl = `${getEndpoint(
           config.environment,
         )}/products_config`;
-        const productsConfigPromise = postData(
-          productsConfigUrl,
-          productsConfigPayload,
-        );
         const locale = getCurrentLocale();
         const servicesUrl = new URL(
           `${getEndpoint(config.environment)}/services`,
@@ -134,56 +129,86 @@ window.Sentry = Sentry;
         if (locale) {
           servicesUrl.searchParams.append('locale', locale);
         }
-        const servicesPromise = fetchWithTimeout(
-          servicesUrl.toString(),
-          {},
-          10000,
-        );
-        const [productsConfigResponse, servicesResponse] = await Promise.all([
-          productsConfigPromise,
-          servicesPromise,
-        ]);
 
-        if (productsConfigResponse.ok && servicesResponse.ok) {
-          const partnerConstraints = await productsConfigResponse.json();
-          const generalConstraints = await servicesResponse.json();
-
-          const previewBvnMfa = config.previewBVNMFA;
-          if (previewBvnMfa) {
-            generalConstraints.hosted_web.biometric_kyc.NG.id_types.BVN_MFA = {
-              id_number_regex: '^[0-9]{11}$',
-              label: 'Bank Verification Number (with OTP)',
-              required_fields: [
-                'country',
-                'id_type',
-                'session_id',
-                'user_id',
-                'job_id',
-              ],
-              test_data: '00000000000',
+        let partnerConstraints;
+        let servicesResponse;
+        if (cachedPartnerConstraints) {
+          // products_config already succeeded on a prior attempt; only retry
+          // the /services leg.
+          partnerConstraints = cachedPartnerConstraints;
+          servicesResponse = await fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          if (!servicesResponse.ok) {
+            initApiFailure = {
+              failedRequests: ['services'],
+              productsConfigStatus: 200,
+              servicesStatus: servicesResponse.status,
             };
+            throw new Error('Failed to get supported ID types');
           }
+        } else {
+          const productsConfigPromise = postData(
+            productsConfigUrl,
+            productsConfigPayload,
+          );
+          const servicesPromise = fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          const [productsConfigResponse, servicesResp] = await Promise.all([
+            productsConfigPromise,
+            servicesPromise,
+          ]);
+          servicesResponse = servicesResp;
+          if (!productsConfigResponse.ok || !servicesResponse.ok) {
+            initApiFailure = buildInitApiFailure(
+              productsConfigResponse,
+              servicesResponse,
+            );
+            throw new Error('Failed to get supported ID types');
+          }
+          partnerConstraints = await productsConfigResponse.json();
+          cachedPartnerConstraints = partnerConstraints;
+        }
+        const generalConstraints = await servicesResponse.json();
 
-          return {
-            partnerConstraints,
-            generalConstraints: generalConstraints.hosted_web.biometric_kyc,
+        const previewBvnMfa = config.previewBVNMFA;
+        if (previewBvnMfa) {
+          generalConstraints.hosted_web.biometric_kyc.NG.id_types.BVN_MFA = {
+            id_number_regex: '^[0-9]{11}$',
+            label: 'Bank Verification Number (with OTP)',
+            required_fields: [
+              'country',
+              'id_type',
+              'session_id',
+              'user_id',
+              'job_id',
+            ],
+            test_data: '00000000000',
           };
         }
-        initApiFailure = buildInitApiFailure(
-          productsConfigResponse,
-          servicesResponse,
-        );
-        throw new Error('Failed to get supported ID types');
+
+        return {
+          partnerConstraints,
+          generalConstraints: generalConstraints.hosted_web.biometric_kyc,
+        };
       } catch (e) {
-        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        // HTTP failures have initApiFailure !== null — deterministic, never
+        // retry. Network-level failures are tagged by `fetchWithTimeout` with
+        // `.isNetworkError = true`; downstream errors (JSON parse TypeError,
+        // property access on undefined, etc.) are not flagged and are
+        // surfaced immediately.
         const isNetworkError =
-          initApiFailure === null &&
-          (e instanceof TypeError || e.name === 'AbortError');
+          initApiFailure === null && e && e.isNetworkError === true;
         if (!isNetworkError || attempt === MAX_ATTEMPTS) {
           captureInitApiFailure(e, initApiFailure);
           throw new Error('Failed to get supported ID types', { cause: e });
         }
-        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        // Linear backoff: 1 s, then 2 s before the third attempt.
         await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
     }

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -89,6 +89,16 @@ window.Sentry = Sentry;
     });
   }
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
     const payload = {
       token: config.token,
@@ -112,29 +122,49 @@ window.Sentry = Sentry;
       url.searchParams.append('locale', locale);
     }
 
-    try {
-      const response = await fetch(url.toString(), fetchConfig);
-      // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
-      // an HTTP failure here would parse JSON of an error body and silently
-      // return undefined without a Sentry event. Explicitly throw so the
-      // catch tags the request and the status before re-throwing.
-      if (!response.ok) {
-        const err = new Error('Failed to get supported ID types');
-        err.httpStatus = response.status;
-        throw err;
-      }
-      const json = await response.json();
+    // iOS Safari (especially iOS 18+) intermittently fails with
+    // "TypeError: Load failed" — a transient network-level error that almost
+    // always succeeds on retry. Retry up to 2 times (3 total attempts) with
+    // exponential backoff. Only network errors (TypeError / AbortError from
+    // the timeout) are retried; HTTP errors are deterministic and are not.
+    const MAX_ATTEMPTS = 3;
 
-      return json.valid_documents;
-    } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          area: 'init_api',
-          failedRequest: 'valid_documents',
-          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
-        },
-      });
-      throw new Error('Failed to get supported ID types', { cause: e });
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const response = await fetchWithTimeout(
+          url.toString(),
+          fetchConfig,
+          10000,
+        );
+        // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
+        // an HTTP failure here would parse JSON of an error body and silently
+        // return undefined without a Sentry event. Explicitly throw so the
+        // catch tags the request and the status before re-throwing.
+        if (!response.ok) {
+          const err = new Error('Failed to get supported ID types');
+          err.httpStatus = response.status;
+          throw err;
+        }
+        const json = await response.json();
+        return json.valid_documents;
+      } catch (e) {
+        // HTTP errors are not transient — fail immediately without retrying.
+        const isNetworkError =
+          e instanceof TypeError || e.name === 'AbortError';
+        if (!isNetworkError || attempt === MAX_ATTEMPTS) {
+          Sentry.captureException(e, {
+            tags: {
+              area: 'init_api',
+              failedRequest: 'valid_documents',
+              ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+              ...(attempt > 1 ? { retryAttempt: String(attempt) } : {}),
+            },
+          });
+          throw new Error('Failed to get supported ID types', { cause: e });
+        }
+        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+      }
     }
   }
 
@@ -221,9 +251,19 @@ window.Sentry = Sentry;
 
         activeScreen = LoadingScreen;
 
-        const productConstraints = await getProductConstraints();
-        initializeSession(productConstraints);
-        getPartnerParams();
+        try {
+          const productConstraints = await getProductConstraints();
+          initializeSession(productConstraints);
+          getPartnerParams();
+        } catch (e) {
+          // After all retry attempts are exhausted, signal the parent frame so
+          // the SDK calls config.onError rather than leaving the user on an
+          // infinite loading spinner.
+          (referenceWindow.parent || referenceWindow).postMessage(
+            'SmileIdentity::Error',
+            '*',
+          );
+        }
       }
     },
     false,

--- a/packages/embed/src/js/doc-verification.js
+++ b/packages/embed/src/js/doc-verification.js
@@ -17,6 +17,7 @@ import {
   shouldSkipSelection,
   idInfoToIdSelection,
 } from './id-info-utils.js';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 // Expose Sentry on the iframe window so the standalone `smart-camera-web`
 // web component (which has no @sentry/browser dep of its own) can report
@@ -90,14 +91,8 @@ window.Sentry = Sentry;
   }
 
   // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
-    );
-  }
+  // Imported from `./fetch-with-retry.js` so the timeout/tagging logic stays
+  // in sync across all iframe entry points.
 
   async function getProductConstraints() {
     const payload = {
@@ -125,8 +120,9 @@ window.Sentry = Sentry;
     // iOS Safari (especially iOS 18+) intermittently fails with
     // "TypeError: Load failed" — a transient network-level error that almost
     // always succeeds on retry. Retry up to 2 times (3 total attempts) with
-    // exponential backoff. Only network errors (TypeError / AbortError from
-    // the timeout) are retried; HTTP errors are deterministic and are not.
+    // linear backoff (1 s, 2 s). Only fetch-level network errors (tagged by
+    // `fetchWithTimeout` with `.isNetworkError = true`) are retried; HTTP
+    // errors and downstream parse failures are deterministic.
     const MAX_ATTEMPTS = 3;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -149,8 +145,7 @@ window.Sentry = Sentry;
         return json.valid_documents;
       } catch (e) {
         // HTTP errors are not transient — fail immediately without retrying.
-        const isNetworkError =
-          e instanceof TypeError || e.name === 'AbortError';
+        const isNetworkError = e && e.isNetworkError === true;
         if (!isNetworkError || attempt === MAX_ATTEMPTS) {
           Sentry.captureException(e, {
             tags: {
@@ -162,7 +157,7 @@ window.Sentry = Sentry;
           });
           throw new Error('Failed to get supported ID types', { cause: e });
         }
-        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        // Linear backoff: 1 s, then 2 s before the third attempt.
         await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
     }

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -74,73 +74,103 @@ import {
     });
   }
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
-    // Captured at the point we know which response.ok was false so the catch
-    // below can attach response-level detail to the Sentry event. Null when
-    // the failure is a promise rejection (network drop, abort, etc.) rather
-    // than a non-OK HTTP response.
-    let initApiFailure = null;
-    try {
-      const productsConfigPayload = {
-        partner_id: config.partner_details.partner_id,
-        token: config.token,
-        partner_params,
-      };
+    // iOS Safari (especially iOS 18+) intermittently fails with
+    // "TypeError: Load failed" — a transient network-level error that almost
+    // always succeeds on retry. Retry up to 2 times (3 total attempts) with
+    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // deterministic and are never retried.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      // Captured at the point we know which response.ok was false so the catch
+      // below can attach response-level detail to the Sentry event. Null when
+      // the failure is a promise rejection (network drop, abort, etc.) rather
+      // than a non-OK HTTP response.
+      let initApiFailure = null;
+      try {
+        const productsConfigPayload = {
+          partner_id: config.partner_details.partner_id,
+          token: config.token,
+          partner_params,
+        };
 
-      const productsConfigUrl = `${getEndpoint(
-        config.environment,
-      )}/products_config`;
-      const productsConfigPromise = postData(
-        productsConfigUrl,
-        productsConfigPayload,
-      );
-      const locale = getCurrentLocale();
-      const servicesUrl = new URL(
-        `${getEndpoint(config.environment)}/services`,
-      );
-      if (locale) {
-        servicesUrl.searchParams.append('locale', locale);
-      }
-      const servicesPromise = fetch(servicesUrl.toString());
-      const [productsConfigResponse, servicesResponse] = await Promise.all([
-        productsConfigPromise,
-        servicesPromise,
-      ]);
+        const productsConfigUrl = `${getEndpoint(
+          config.environment,
+        )}/products_config`;
+        const productsConfigPromise = postData(
+          productsConfigUrl,
+          productsConfigPayload,
+        );
+        const locale = getCurrentLocale();
+        const servicesUrl = new URL(
+          `${getEndpoint(config.environment)}/services`,
+        );
+        if (locale) {
+          servicesUrl.searchParams.append('locale', locale);
+        }
+        const servicesPromise = fetchWithTimeout(
+          servicesUrl.toString(),
+          {},
+          10000,
+        );
+        const [productsConfigResponse, servicesResponse] = await Promise.all([
+          productsConfigPromise,
+          servicesPromise,
+        ]);
 
-      if (productsConfigResponse.ok && servicesResponse.ok) {
-        const partnerConstraints = await productsConfigResponse.json();
-        const generalConstraints = await servicesResponse.json();
-        ngBankCodes = generalConstraints.bank_codes;
+        if (productsConfigResponse.ok && servicesResponse.ok) {
+          const partnerConstraints = await productsConfigResponse.json();
+          const generalConstraints = await servicesResponse.json();
+          ngBankCodes = generalConstraints.bank_codes;
 
-        const previewBvnMfa = config.previewBVNMFA;
-        if (previewBvnMfa) {
-          generalConstraints.hosted_web.enhanced_kyc.NG.id_types.BVN_MFA = {
-            id_number_regex: '^[0-9]{11}$',
-            label: 'Bank Verification Number (with OTP)',
-            required_fields: [
-              'country',
-              'id_type',
-              'session_id',
-              'user_id',
-              'job_id',
-            ],
-            test_data: '00000000000',
+          const previewBvnMfa = config.previewBVNMFA;
+          if (previewBvnMfa) {
+            generalConstraints.hosted_web.enhanced_kyc.NG.id_types.BVN_MFA = {
+              id_number_regex: '^[0-9]{11}$',
+              label: 'Bank Verification Number (with OTP)',
+              required_fields: [
+                'country',
+                'id_type',
+                'session_id',
+                'user_id',
+                'job_id',
+              ],
+              test_data: '00000000000',
+            };
+          }
+
+          return {
+            partnerConstraints,
+            generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
           };
         }
-
-        return {
-          partnerConstraints,
-          generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
-        };
+        initApiFailure = buildInitApiFailure(
+          productsConfigResponse,
+          servicesResponse,
+        );
+        throw new Error('Failed to get supported ID types');
+      } catch (e) {
+        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        const isNetworkError =
+          initApiFailure === null &&
+          (e instanceof TypeError || e.name === 'AbortError');
+        if (!isNetworkError || attempt === MAX_ATTEMPTS) {
+          captureInitApiFailure(e, initApiFailure);
+          throw new Error('Failed to get supported ID types', { cause: e });
+        }
+        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
-      initApiFailure = buildInitApiFailure(
-        productsConfigResponse,
-        servicesResponse,
-      );
-      throw new Error('Failed to get supported ID types');
-    } catch (e) {
-      captureInitApiFailure(e, initApiFailure);
-      throw new Error('Failed to get supported ID types', { cause: e });
     }
   }
 
@@ -191,10 +221,17 @@ import {
         });
         activeScreen = LoadingScreen;
         getPartnerParams();
-        const { partnerConstraints, generalConstraints } =
-          await getProductConstraints();
-        productConstraints = generalConstraints;
-        initializeSession(generalConstraints, partnerConstraints);
+        try {
+          const { partnerConstraints, generalConstraints } =
+            await getProductConstraints();
+          productConstraints = generalConstraints;
+          initializeSession(generalConstraints, partnerConstraints);
+        } catch (e) {
+          (referenceWindow.parent || referenceWindow).postMessage(
+            'SmileIdentity::Error',
+            '*',
+          );
+        }
       }
     },
     false,

--- a/packages/embed/src/js/ekyc.js
+++ b/packages/embed/src/js/ekyc.js
@@ -22,6 +22,7 @@ import {
   buildInitApiFailure,
   captureInitApiFailure,
 } from './init-api-sentry.js';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 (function eKYC() {
   'use strict';
@@ -60,27 +61,21 @@ import {
   let skipInputScreen = false;
 
   async function postData(url = '', data = {}, shouldSignPayload = false) {
-    return fetch(url, {
-      method: 'POST',
-      mode: 'cors',
-      cache: 'no-cache',
-      headers: {
-        ...(shouldSignPayload &&
-          (await getHeaders(data, config.partner_details.partner_id))),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
+    return fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        mode: 'cors',
+        cache: 'no-cache',
+        headers: {
+          ...(shouldSignPayload &&
+            (await getHeaders(data, config.partner_details.partner_id))),
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
       },
-      body: JSON.stringify(data),
-    });
-  }
-
-  // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
+      10000,
     );
   }
 
@@ -88,9 +83,13 @@ import {
     // iOS Safari (especially iOS 18+) intermittently fails with
     // "TypeError: Load failed" — a transient network-level error that almost
     // always succeeds on retry. Retry up to 2 times (3 total attempts) with
-    // exponential backoff. HTTP failures (initApiFailure !== null) are
+    // linear backoff (1 s, 2 s). HTTP failures (initApiFailure !== null) are
     // deterministic and are never retried.
     const MAX_ATTEMPTS = 3;
+    // Reason: cache the parsed products_config across attempts so a transient
+    // /services failure doesn't re-issue the (possibly side-effecting)
+    // /products_config POST that already succeeded.
+    let cachedPartnerConstraints = null;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       // Captured at the point we know which response.ok was false so the catch
       // below can attach response-level detail to the Sentry event. Null when
@@ -107,10 +106,6 @@ import {
         const productsConfigUrl = `${getEndpoint(
           config.environment,
         )}/products_config`;
-        const productsConfigPromise = postData(
-          productsConfigUrl,
-          productsConfigPayload,
-        );
         const locale = getCurrentLocale();
         const servicesUrl = new URL(
           `${getEndpoint(config.environment)}/services`,
@@ -118,57 +113,83 @@ import {
         if (locale) {
           servicesUrl.searchParams.append('locale', locale);
         }
-        const servicesPromise = fetchWithTimeout(
-          servicesUrl.toString(),
-          {},
-          10000,
-        );
-        const [productsConfigResponse, servicesResponse] = await Promise.all([
-          productsConfigPromise,
-          servicesPromise,
-        ]);
 
-        if (productsConfigResponse.ok && servicesResponse.ok) {
-          const partnerConstraints = await productsConfigResponse.json();
-          const generalConstraints = await servicesResponse.json();
-          ngBankCodes = generalConstraints.bank_codes;
-
-          const previewBvnMfa = config.previewBVNMFA;
-          if (previewBvnMfa) {
-            generalConstraints.hosted_web.enhanced_kyc.NG.id_types.BVN_MFA = {
-              id_number_regex: '^[0-9]{11}$',
-              label: 'Bank Verification Number (with OTP)',
-              required_fields: [
-                'country',
-                'id_type',
-                'session_id',
-                'user_id',
-                'job_id',
-              ],
-              test_data: '00000000000',
+        let partnerConstraints;
+        let servicesResponse;
+        if (cachedPartnerConstraints) {
+          partnerConstraints = cachedPartnerConstraints;
+          servicesResponse = await fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          if (!servicesResponse.ok) {
+            initApiFailure = {
+              failedRequests: ['services'],
+              productsConfigStatus: 200,
+              servicesStatus: servicesResponse.status,
             };
+            throw new Error('Failed to get supported ID types');
           }
+        } else {
+          const productsConfigPromise = postData(
+            productsConfigUrl,
+            productsConfigPayload,
+          );
+          const servicesPromise = fetchWithTimeout(
+            servicesUrl.toString(),
+            {},
+            10000,
+          );
+          const [productsConfigResponse, servicesResp] = await Promise.all([
+            productsConfigPromise,
+            servicesPromise,
+          ]);
+          servicesResponse = servicesResp;
+          if (!productsConfigResponse.ok || !servicesResponse.ok) {
+            initApiFailure = buildInitApiFailure(
+              productsConfigResponse,
+              servicesResponse,
+            );
+            throw new Error('Failed to get supported ID types');
+          }
+          partnerConstraints = await productsConfigResponse.json();
+          cachedPartnerConstraints = partnerConstraints;
+        }
+        const generalConstraints = await servicesResponse.json();
+        ngBankCodes = generalConstraints.bank_codes;
 
-          return {
-            partnerConstraints,
-            generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
+        const previewBvnMfa = config.previewBVNMFA;
+        if (previewBvnMfa) {
+          generalConstraints.hosted_web.enhanced_kyc.NG.id_types.BVN_MFA = {
+            id_number_regex: '^[0-9]{11}$',
+            label: 'Bank Verification Number (with OTP)',
+            required_fields: [
+              'country',
+              'id_type',
+              'session_id',
+              'user_id',
+              'job_id',
+            ],
+            test_data: '00000000000',
           };
         }
-        initApiFailure = buildInitApiFailure(
-          productsConfigResponse,
-          servicesResponse,
-        );
-        throw new Error('Failed to get supported ID types');
+
+        return {
+          partnerConstraints,
+          generalConstraints: generalConstraints.hosted_web.enhanced_kyc,
+        };
       } catch (e) {
-        // HTTP failures have initApiFailure !== null — deterministic, never retry.
+        // HTTP failures have initApiFailure !== null — deterministic, never
+        // retry. Network-level failures are tagged by `fetchWithTimeout` with
+        // `.isNetworkError = true`.
         const isNetworkError =
-          initApiFailure === null &&
-          (e instanceof TypeError || e.name === 'AbortError');
+          initApiFailure === null && e && e.isNetworkError === true;
         if (!isNetworkError || attempt === MAX_ATTEMPTS) {
           captureInitApiFailure(e, initApiFailure);
           throw new Error('Failed to get supported ID types', { cause: e });
         }
-        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        // Linear backoff: 1 s, then 2 s before the third attempt.
         await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
     }

--- a/packages/embed/src/js/enhanced-document-verification.js
+++ b/packages/embed/src/js/enhanced-document-verification.js
@@ -15,6 +15,7 @@ import {
   shouldSkipSelection,
   idInfoToIdSelection,
 } from './id-info-utils.js';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 // Expose Sentry on the iframe window so the standalone `smart-camera-web`
 // web component (which has no @sentry/browser dep of its own) can report
@@ -79,15 +80,8 @@ function applyPageTranslations() {
   let fileToUpload;
   let uploadURL;
 
-  // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
-    );
-  }
+  // `fetchWithTimeout` is imported from `./fetch-with-retry.js` so the
+  // timeout/tagging logic stays in sync across all iframe entry points.
 
   async function getProductConstraints() {
     const locale = getCurrentLocale();
@@ -99,8 +93,8 @@ function applyPageTranslations() {
     // iOS Safari (especially iOS 18+) intermittently fails with
     // "TypeError: Load failed" — a transient network-level error that almost
     // always succeeds on retry. Retry up to 2 times (3 total attempts) with
-    // exponential backoff. HTTP errors (e.httpStatus) are deterministic and
-    // are never retried.
+    // linear backoff (1 s, 2 s). HTTP errors (e.httpStatus) are deterministic
+    // and are never retried.
     const MAX_ATTEMPTS = 3;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
@@ -118,8 +112,9 @@ function applyPageTranslations() {
 
         return json.hosted_web.enhanced_document_verification;
       } catch (e) {
-        const isNetworkError =
-          e instanceof TypeError || e.name === 'AbortError';
+        // Only fetch-level network errors (tagged by `fetchWithTimeout`) are
+        // retried; downstream JSON parse or property access TypeErrors are not.
+        const isNetworkError = e && e.isNetworkError === true;
         if (!isNetworkError || attempt === MAX_ATTEMPTS) {
           Sentry.captureException(e, {
             tags: {
@@ -131,7 +126,7 @@ function applyPageTranslations() {
           });
           throw new Error('Failed to get supported ID types', { cause: e });
         }
-        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        // Linear backoff: 1 s, then 2 s before the third attempt.
         await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
       }
     }

--- a/packages/embed/src/js/enhanced-document-verification.js
+++ b/packages/embed/src/js/enhanced-document-verification.js
@@ -79,6 +79,16 @@ function applyPageTranslations() {
   let fileToUpload;
   let uploadURL;
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
     const locale = getCurrentLocale();
     const url = new URL(`${getEndpoint(config.environment)}/services`);
@@ -86,29 +96,44 @@ function applyPageTranslations() {
       url.searchParams.append('locale', locale);
     }
 
-    try {
-      const response = await fetch(url.toString());
-      // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
-      // an HTTP failure here would parse JSON of an error body and silently
-      // return undefined without a Sentry event. Explicitly throw so the
-      // catch tags the request and the status before re-throwing.
-      if (!response.ok) {
-        const err = new Error('Failed to get supported ID types');
-        err.httpStatus = response.status;
-        throw err;
-      }
-      const json = await response.json();
+    // iOS Safari (especially iOS 18+) intermittently fails with
+    // "TypeError: Load failed" — a transient network-level error that almost
+    // always succeeds on retry. Retry up to 2 times (3 total attempts) with
+    // exponential backoff. HTTP errors (e.httpStatus) are deterministic and
+    // are never retried.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const response = await fetchWithTimeout(url.toString(), {}, 10000);
+        // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
+        // an HTTP failure here would parse JSON of an error body and silently
+        // return undefined without a Sentry event. Explicitly throw so the
+        // catch tags the request and the status before re-throwing.
+        if (!response.ok) {
+          const err = new Error('Failed to get supported ID types');
+          err.httpStatus = response.status;
+          throw err;
+        }
+        const json = await response.json();
 
-      return json.hosted_web.enhanced_document_verification;
-    } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          area: 'init_api',
-          failedRequest: 'services',
-          ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
-        },
-      });
-      throw new Error('Failed to get supported ID types', { cause: e });
+        return json.hosted_web.enhanced_document_verification;
+      } catch (e) {
+        const isNetworkError =
+          e instanceof TypeError || e.name === 'AbortError';
+        if (!isNetworkError || attempt === MAX_ATTEMPTS) {
+          Sentry.captureException(e, {
+            tags: {
+              area: 'init_api',
+              failedRequest: 'services',
+              ...(e.httpStatus ? { httpStatus: String(e.httpStatus) } : {}),
+              ...(attempt > 1 ? { retryAttempt: String(attempt) } : {}),
+            },
+          });
+          throw new Error('Failed to get supported ID types', { cause: e });
+        }
+        // Exponential backoff: 1 s, then 2 s before the third attempt.
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+      }
     }
   }
 
@@ -146,9 +171,16 @@ function applyPageTranslations() {
         });
         activeScreen = LoadingScreen;
 
-        productConstraints = await getProductConstraints();
-        initializeSession(productConstraints);
-        getPartnerParams();
+        try {
+          productConstraints = await getProductConstraints();
+          initializeSession(productConstraints);
+          getPartnerParams();
+        } catch (e) {
+          (referenceWindow.parent || referenceWindow).postMessage(
+            'SmileIdentity::Error',
+            '*',
+          );
+        }
       }
     },
     false,

--- a/packages/embed/src/js/fetch-with-retry.js
+++ b/packages/embed/src/js/fetch-with-retry.js
@@ -1,0 +1,73 @@
+// Shared fetch + retry helpers used by the iframe product entry points to
+// recover from the iOS Safari (especially iOS 18+) intermittent
+// "TypeError: Load failed" failure that almost always succeeds on retry.
+//
+// Two helpers are exported:
+//   - `fetchWithTimeout` wraps `fetch` with a per-attempt AbortController
+//     timeout and tags errors thrown by the underlying fetch with
+//     `.isNetworkError = true` so callers can distinguish them from
+//     downstream JSON-parse / property-access TypeErrors.
+//   - `withNetworkRetry` retries a thunk up to `maxAttempts` times with
+//     linear backoff (1 s, 2 s, …). Only errors flagged with
+//     `.isNetworkError === true` are retried; HTTP failures (4xx/5xx) and
+//     downstream parsing errors are surfaced immediately.
+
+// Wraps fetch with a per-attempt AbortController timeout. Rejects with an
+// AbortError if the timeout elapses. Tags the rejection (AbortError on
+// timeout or TypeError on network failure) with `.isNetworkError = true`
+// so a surrounding retry classifier can distinguish fetch-level failures
+// from downstream errors (e.g. `response.json()` TypeError on malformed
+// payloads, or property access on `undefined`) that should not be retried.
+export function fetchWithTimeout(url, options, timeoutMs = 10000) {
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, { ...options, signal: controller.signal })
+    .catch((e) => {
+      if (e && (e.name === 'AbortError' || e instanceof TypeError)) {
+        // Reason: tag at the source so the retry classifier doesn't need to
+        // re-derive whether the error originated from the fetch itself.
+        try {
+          e.isNetworkError = true;
+        } catch {
+          // Some error objects (e.g. frozen) reject property assignment;
+          // fall back to letting the classifier treat unflagged errors as
+          // non-retryable, which is the safer default.
+        }
+      }
+      throw e;
+    })
+    .finally(() => clearTimeout(timerId));
+}
+
+// Retries `fn` up to `maxAttempts` times with linear backoff
+// (`baseDelayMs * attempt` — 1 s before attempt 2, 2 s before attempt 3 by
+// default). Only errors flagged `.isNetworkError === true` by
+// `fetchWithTimeout` are retried; everything else (HTTP failures wrapped
+// by the caller, JSON parse TypeErrors, etc.) is thrown immediately.
+// `shouldRetry(error, attempt)` can override the default classifier.
+export async function withNetworkRetry(
+  fn,
+  { maxAttempts = 3, baseDelayMs = 1000, shouldRetry } = {},
+) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await fn(attempt);
+    } catch (e) {
+      lastError = e;
+      const retryable = shouldRetry
+        ? shouldRetry(e, attempt)
+        : e && e.isNetworkError === true;
+      if (!retryable || attempt === maxAttempts) throw e;
+      // Linear backoff: 1 s before attempt 2, 2 s before attempt 3.
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => {
+        setTimeout(resolve, baseDelayMs * attempt);
+      });
+    }
+  }
+  // Unreachable — the loop either returns from `fn` or throws — but TS-style
+  // linters appreciate an explicit terminator.
+  throw lastError;
+}

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -49,6 +49,16 @@ import * as Sentry from '@sentry/browser';
     activeScreen = element;
   }
 
+  // Wraps fetch with a per-attempt AbortController timeout.
+  // Rejects with an AbortError if the timeout elapses.
+  function fetchWithTimeout(url, options, timeoutMs = 10000) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+      clearTimeout(timerId),
+    );
+  }
+
   async function getProductConstraints() {
     const payload = {
       token: config.token,
@@ -75,7 +85,7 @@ import * as Sentry from '@sentry/browser';
     }
 
     try {
-      const response = await fetch(url.toString(), fetchConfig);
+      const response = await fetchWithTimeout(url.toString(), fetchConfig, 10000);
       // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
       // an HTTP failure here would parse JSON of an error body and silently
       // return undefined without a Sentry event. Explicitly throw so the
@@ -120,7 +130,7 @@ import * as Sentry from '@sentry/browser';
     }
 
     try {
-      const response = await fetch(url.toString(), fetchConfig);
+      const response = await fetchWithTimeout(url.toString(), fetchConfig, 10000);
       if (!response.ok) {
         const err = new Error('Failed to get supported ID types');
         err.httpStatus = response.status;
@@ -406,18 +416,23 @@ import * as Sentry from '@sentry/browser';
 
           activeScreen = LoadingScreen;
 
-          const constraintsPromises = [
-            getProductConstraints(),
-            getLegacyProductConstraints(),
-          ];
-          const [productConstraints, legacyConstraints] =
-            await Promise.all(constraintsPromises);
-          verificationMethodMap = transformIdTypesToVerificationMethodMap(
-            config.id_types,
-            productConstraints,
-            legacyConstraints,
-          );
-          initializeForm(SelectIdType, verificationMethodMap);
+          try {
+            const [productConstraints, legacyConstraints] = await Promise.all([
+              getProductConstraints(),
+              getLegacyProductConstraints(),
+            ]);
+            verificationMethodMap = transformIdTypesToVerificationMethodMap(
+              config.id_types,
+              productConstraints,
+              legacyConstraints,
+            );
+            initializeForm(SelectIdType, verificationMethodMap);
+          } catch (e) {
+            (referenceWindow.parent || referenceWindow).postMessage(
+              'SmileIdentity::Error',
+              '*',
+            );
+          }
         } else if (event.data.includes('SmileIdentity::ChildPageReady')) {
           publishMessage(config);
         }

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -85,7 +85,11 @@ import * as Sentry from '@sentry/browser';
     }
 
     try {
-      const response = await fetchWithTimeout(url.toString(), fetchConfig, 10000);
+      const response = await fetchWithTimeout(
+        url.toString(),
+        fetchConfig,
+        10000,
+      );
       // `fetch` only rejects on network errors — 4xx/5xx still resolve, so
       // an HTTP failure here would parse JSON of an error body and silently
       // return undefined without a Sentry event. Explicitly throw so the
@@ -130,7 +134,11 @@ import * as Sentry from '@sentry/browser';
     }
 
     try {
-      const response = await fetchWithTimeout(url.toString(), fetchConfig, 10000);
+      const response = await fetchWithTimeout(
+        url.toString(),
+        fetchConfig,
+        10000,
+      );
       if (!response.ok) {
         const err = new Error('Failed to get supported ID types');
         err.httpStatus = response.status;

--- a/packages/embed/src/js/product-selection.js
+++ b/packages/embed/src/js/product-selection.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser';
+import { fetchWithTimeout, withNetworkRetry } from './fetch-with-retry.js';
 
 (function productSelection() {
   'use strict';
@@ -50,14 +51,7 @@ import * as Sentry from '@sentry/browser';
   }
 
   // Wraps fetch with a per-attempt AbortController timeout.
-  // Rejects with an AbortError if the timeout elapses.
-  function fetchWithTimeout(url, options, timeoutMs = 10000) {
-    const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-    return fetch(url, { ...options, signal: controller.signal }).finally(() =>
-      clearTimeout(timerId),
-    );
-  }
+  // Imported from `./fetch-with-retry.js`.
 
   async function getProductConstraints() {
     const payload = {
@@ -425,10 +419,36 @@ import * as Sentry from '@sentry/browser';
           activeScreen = LoadingScreen;
 
           try {
-            const [productConstraints, legacyConstraints] = await Promise.all([
-              getProductConstraints(),
-              getLegacyProductConstraints(),
-            ]);
+            // iOS Safari (especially iOS 18+) intermittently fails with
+            // "TypeError: Load failed" — a transient network-level error that
+            // almost always succeeds on retry. Wrap the two init-API calls in
+            // `withNetworkRetry` so a transient fetch failure is retried with
+            // linear backoff (1 s, 2 s). HTTP failures bubble up immediately
+            // — they're already captured by `getProductConstraints` /
+            // `getLegacyProductConstraints` with Sentry tagging.
+            const [productConstraints, legacyConstraints] =
+              await withNetworkRetry(
+                () =>
+                  Promise.all([
+                    getProductConstraints(),
+                    getLegacyProductConstraints(),
+                  ]),
+                {
+                  // `getProductConstraints` / `getLegacyProductConstraints`
+                  // wrap fetch failures in `new Error('Failed to get supported
+                  // ID types', { cause: e })`, so the `.isNetworkError` flag
+                  // sits on `error.cause` rather than `error` itself. Walk the
+                  // cause chain when deciding whether to retry.
+                  shouldRetry: (e) => {
+                    let cur = e;
+                    while (cur) {
+                      if (cur.isNetworkError === true) return true;
+                      cur = cur.cause;
+                    }
+                    return false;
+                  },
+                },
+              );
             verificationMethodMap = transformIdTypesToVerificationMethodMap(
               config.id_types,
               productConstraints,
@@ -436,6 +456,15 @@ import * as Sentry from '@sentry/browser';
             );
             initializeForm(SelectIdType, verificationMethodMap);
           } catch (e) {
+            // After all retry attempts are exhausted, signal the parent frame
+            // so the SDK calls config.onError rather than leaving the user on
+            // an infinite loading spinner. The inner `getProductConstraints` /
+            // `getLegacyProductConstraints` already capture to Sentry; capture
+            // here too so the outer failure (and its retry status) is
+            // observable rather than silently swallowed.
+            Sentry.captureException(e, {
+              tags: { area: 'init_api', failedRequest: 'product_selection' },
+            });
             (referenceWindow.parent || referenceWindow).postMessage(
               'SmileIdentity::Error',
               '*',


### PR DESCRIPTION
### **User description**
## Problem

iOS Safari 18+ (primarily iPhone, iOS 18.7) intermittently throws `TypeError: Load failed` on the init-API calls at page load. These are transient network-level failures caught by Sentry as **WEB-CLIENT-9F** (and related variants across other products).

- **1,259 events** since July 2024, still active
- **94% iPhone**, 56% iOS 18.7, Mobile Safari
- Affects: `/valid_documents`, `/services`, `/products_config` fetch calls on all product iframe pages

## Fix

**`fetchWithTimeout()` helper** — wraps `fetch` with an `AbortController` that fires after 10 s, preventing the loading screen from hanging indefinitely.

**Retry loop in `getProductConstraints()`** — up to 3 total attempts with exponential backoff (1 s → 2 s). Only network errors (`TypeError` / `AbortError`) are retried; HTTP errors are deterministic and fail immediately.

**Error postMessage at call site** — previously, if all retries failed the user was silently stuck on the loading screen. Now posts `SmileIdentity::Error` to the parent frame so `config.onError` fires and the SDK closes cleanly.

## Files changed

- `doc-verification.js` — single fetch (`/valid_documents`), full retry loop
- `enhanced-document-verification.js` — single fetch (`/services`), full retry loop
- `biometric-kyc.js` — parallel fetch (`/products_config` + `/services`), retry loop on `/services`
- `ekyc.js` — same pattern as biometric-kyc
- `basic-kyc.js` — same pattern, `/v1/` paths
- `product-selection.js` — timeout applied to both `getProductConstraints` and `getLegacyProductConstraints` fetches


___

### **PR Type**
Bug fix


___

### **Description**
- Add `fetchWithTimeout()` helper with 10s AbortController timeout

- Retry network errors up to 3 attempts with exponential backoff

- Post `SmileIdentity::Error` to parent on final failure

- Applied across all product iframe initialization files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fetch call (init API)"] -- "timeout 10s" --> B["fetchWithTimeout()"]
  B -- "success" --> C["return data"]
  B -- "network error" --> D["retry loop (max 3)"]
  D -- "backoff 1s/2s" --> B
  D -- "all attempts fail" --> E["postMessage SmileIdentity::Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>basic-kyc.js</strong><dd><code>Add fetch timeout and retry for basic-kyc init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/basic-kyc.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Wrapped <code>getProductConstraints()</code> in a retry loop (3 attempts, <br>exponential backoff)<br> <li> Only retries network errors (TypeError/AbortError), not HTTP errors<br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-9fc764bf162b22278c4700f1a9c471e7edf5a0751f640a85b2a8f49d8f8b1155">+105/-68</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>biometric-kyc.js</strong><dd><code>Add fetch timeout and retry for biometric-kyc init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/biometric-kyc.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Wrapped <code>getProductConstraints()</code> in a retry loop (3 attempts, <br>exponential backoff)<br> <li> Only retries network errors (TypeError/AbortError), not HTTP errors<br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-f5be2e469a49bbd0cbecc5c18f86fd8c6b3ece0d894267283f0302b4c905f50d">+101/-64</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>doc-verification.js</strong><dd><code>Add fetch timeout and retry for doc-verification init</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/doc-verification.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Wrapped <code>getProductConstraints()</code> in a retry loop (3 attempts, <br>exponential backoff)<br> <li> Added <code>retryAttempt</code> tag to Sentry error capture when retries occurred<br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-ac98d8d890cb7e0009aba6a97be503a146e059f2ea0d1add65f9bca878fa5cff">+65/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ekyc.js</strong><dd><code>Add fetch timeout and retry for ekyc init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/ekyc.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Wrapped <code>getProductConstraints()</code> in a retry loop (3 attempts, <br>exponential backoff)<br> <li> Only retries network errors (TypeError/AbortError), not HTTP errors<br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-d96aafd656e4402106db69c724ad7415e0f6e30206c85c90f345c49ec7a5ec2a">+103/-66</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification.js</strong><dd><code>Add fetch timeout and retry for enhanced-doc-verification init</code></dd></summary>
<hr>

packages/embed/src/js/enhanced-document-verification.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Wrapped <code>getProductConstraints()</code> in a retry loop (3 attempts, <br>exponential backoff)<br> <li> Added <code>retryAttempt</code> tag to Sentry error capture when retries occurred<br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-ebd071140290922ac1d9cb1d1faec8f1e0f100f965490c81a28efc589e871911">+57/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>product-selection.js</strong><dd><code>Add fetch timeout for product-selection init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/product-selection.js

<ul><li>Added <code>fetchWithTimeout()</code> helper wrapping fetch with AbortController<br> <li> Replaced bare <code>fetch</code> calls with <code>fetchWithTimeout</code> in both <br><code>getProductConstraints()</code> and <code>getLegacyProductConstraints()</code><br> <li> Added try/catch at call site to post <code>SmileIdentity::Error</code> on final <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/618/files#diff-ea4f545f0962c77d66b029aee2825c0fd95bffcb15326d65e0483d6c53bc954a">+29/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>