### PR TITLE
fix(selfie): fall back to legacy capture when WebAssembly reftypes are unsupported

### DIFF
--- a/packages/web-components/cypress/e2e/mediapipe-manager-wasm-reftypes.cy.js
+++ b/packages/web-components/cypress/e2e/mediapipe-manager-wasm-reftypes.cy.js
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for the WebAssembly reftypes/externref feature probe
+ * added to mediapipeManager.
+ *
+ * Background: MediaPipe Tasks Vision ships a .wasm that declares an
+ * `externref` global. On older engines (Chrome < 96, Safari < 15,
+ * Firefox < 79) `WebAssembly.instantiate` throws
+ * `CompileError: invalid value type 'externref'`, surfacing in Sentry as
+ * an unhandled rejection (see WEB-CLIENT-Q7). `getMediapipeInstance`
+ * now probes support up-front and rejects with a typed
+ * `UnsupportedMediapipeEnvironmentError` so the legacy selfie-capture
+ * fallback path is used instead.
+ */
+
+describe('MediaPipe Manager WebAssembly reftypes support', () => {
+  const importManager = (win) =>
+    win.eval(
+      "import('/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts')",
+    );
+
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('detects externref support in the current (modern) browser', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+      expect(mod.__testUtils.supportsWasmReftypes()).to.equal(true);
+    });
+  });
+
+  it('returns false when WebAssembly is unavailable', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+      const originalWasm = win.WebAssembly;
+
+      try {
+        // eslint-disable-next-line no-param-reassign
+        delete win.WebAssembly;
+        expect(mod.__testUtils.supportsWasmReftypes()).to.equal(false);
+      } finally {
+        // eslint-disable-next-line no-param-reassign
+        win.WebAssembly = originalWasm;
+      }
+    });
+  });
+
+  it('returns false when WebAssembly.validate rejects the externref module', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+      const originalValidate = win.WebAssembly.validate;
+
+      try {
+        win.WebAssembly.validate = () => false;
+        expect(mod.__testUtils.supportsWasmReftypes()).to.equal(false);
+      } finally {
+        win.WebAssembly.validate = originalValidate;
+      }
+    });
+  });
+
+  it('returns false when WebAssembly.validate throws', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+      const originalValidate = win.WebAssembly.validate;
+
+      try {
+        win.WebAssembly.validate = () => {
+          throw new Error('blocked');
+        };
+        expect(mod.__testUtils.supportsWasmReftypes()).to.equal(false);
+      } finally {
+        win.WebAssembly.validate = originalValidate;
+      }
+    });
+  });
+});
+
+describe('getMediapipeInstance reftypes fallback', () => {
+  const importManager = (win) =>
+    win.eval(
+      "import('/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts')",
+    );
+
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('rejects with UnsupportedMediapipeEnvironmentError when reftypes are unsupported', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+
+      // Pre-seed the cache to simulate an old browser without externref.
+      // eslint-disable-next-line no-param-reassign
+      win.__smileIdentityMediapipe = {
+        instance: null,
+        loaded: false,
+        loading: null,
+        supportsWasmReftypes: false,
+      };
+
+      let caught;
+      try {
+        await mod.getMediapipeInstance();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught, 'getMediapipeInstance should reject').to.not.equal(
+        undefined,
+      );
+      expect(caught).to.be.instanceOf(mod.UnsupportedMediapipeEnvironmentError);
+      expect(caught.name).to.equal('UnsupportedMediapipeEnvironmentError');
+      expect(caught.message).to.match(/externref|reference types/i);
+
+      // Cleanup so other specs sharing the same window are unaffected.
+      // eslint-disable-next-line no-param-reassign
+      delete win.__smileIdentityMediapipe;
+    });
+  });
+
+  it('does not start MediaPipe loading when reftypes are unsupported', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+
+      // eslint-disable-next-line no-param-reassign
+      win.__smileIdentityMediapipe = {
+        instance: null,
+        loaded: false,
+        loading: null,
+        supportsWasmReftypes: false,
+      };
+
+      try {
+        await mod.getMediapipeInstance();
+      } catch {
+        /* expected */
+      }
+
+      const state = win.__smileIdentityMediapipe;
+      expect(state.loading, 'loading promise must not be created').to.equal(
+        null,
+      );
+      expect(state.loaded).to.equal(false);
+      expect(state.instance).to.equal(null);
+
+      // eslint-disable-next-line no-param-reassign
+      delete win.__smileIdentityMediapipe;
+    });
+  });
+
+  it('caches the reftypes probe result across calls', () => {
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+
+      // eslint-disable-next-line no-param-reassign
+      win.__smileIdentityMediapipe = {
+        instance: null,
+        loaded: false,
+        loading: null,
+      };
+
+      const originalValidate = win.WebAssembly.validate;
+      let validateCalls = 0;
+      win.WebAssembly.validate = () => {
+        validateCalls += 1;
+        return false;
+      };
+
+      try {
+        await mod.getMediapipeInstance().catch(() => {});
+        await mod.getMediapipeInstance().catch(() => {});
+        await mod.getMediapipeInstance().catch(() => {});
+
+        expect(
+          validateCalls,
+          'WebAssembly.validate should only be invoked once',
+        ).to.equal(1);
+        expect(win.__smileIdentityMediapipe.supportsWasmReftypes).to.equal(
+          false,
+        );
+      } finally {
+        win.WebAssembly.validate = originalValidate;
+        // eslint-disable-next-line no-param-reassign
+        delete win.__smileIdentityMediapipe;
+      }
+    });
+  });
+});

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
@@ -92,11 +92,22 @@ const supportsWasmReftypes = (): boolean => {
     // Minimal module: magic + version + global section with one externref
     // global (value type 0x6f) initialized to ref.null extern (0xd0 0x6f 0x0b).
     const bytes = new Uint8Array([
-      0x00, 0x61, 0x73, 0x6d, // \0asm magic
-      0x01, 0x00, 0x00, 0x00, // version 1
-      0x06, 0x06, 0x01, // global section, 6 bytes, 1 global
-      0x6f, 0x00, // externref, immutable
-      0xd0, 0x6f, 0x0b, // ref.null extern; end
+      0x00,
+      0x61,
+      0x73,
+      0x6d, // \0asm magic
+      0x01,
+      0x00,
+      0x00,
+      0x00, // version 1
+      0x06,
+      0x06,
+      0x01, // global section, 6 bytes, 1 global
+      0x6f,
+      0x00, // externref, immutable
+      0xd0,
+      0x6f,
+      0x0b, // ref.null extern; end
     ]);
     return WebAssembly.validate(bytes);
   } catch {

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
@@ -234,10 +234,8 @@ export const getMediapipeInstance = async (): Promise<FaceLandmarker> => {
     mediapipeGlobal.supportsWasmReftypes = supportsWasmReftypes();
   }
   if (!mediapipeGlobal.supportsWasmReftypes) {
-    return Promise.reject(
-      new UnsupportedMediapipeEnvironmentError(
-        'WebAssembly reference types (externref) are not supported in this browser; MediaPipe Tasks Vision cannot be loaded.',
-      ),
+    throw new UnsupportedMediapipeEnvironmentError(
+      'WebAssembly reference types (externref) are not supported in this browser; MediaPipe Tasks Vision cannot be loaded.',
     );
   }
 

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
@@ -67,7 +67,47 @@ declare global {
       instance: FaceLandmarker | null;
       loading: Promise<FaceLandmarker> | null;
       loaded: boolean;
+      supportsWasmReftypes?: boolean;
     };
+  }
+}
+
+/**
+ * @description Detects whether the current runtime supports the WebAssembly
+ * reference-types proposal (the `externref` value type). MediaPipe Tasks
+ * Vision ships a .wasm that uses `externref`; on older engines (e.g. Chrome
+ * < 96, Safari < 15, Firefox < 79) `WebAssembly.instantiate` throws
+ * `CompileError: invalid value type 'externref'`. We probe support once with
+ * `WebAssembly.validate` against a tiny module whose only feature is an
+ * `externref`-typed global so callers can short-circuit and fall back to the
+ * legacy selfie capture flow instead of triggering an unhandled rejection.
+ * @returns {boolean} True if the runtime accepts reftypes / externref.
+ */
+const supportsWasmReftypes = (): boolean => {
+  if (typeof WebAssembly === 'undefined' || !WebAssembly.validate) {
+    return false;
+  }
+
+  try {
+    // Minimal module: magic + version + global section with one externref
+    // global (value type 0x6f) initialized to ref.null extern (0xd0 0x6f 0x0b).
+    const bytes = new Uint8Array([
+      0x00, 0x61, 0x73, 0x6d, // \0asm magic
+      0x01, 0x00, 0x00, 0x00, // version 1
+      0x06, 0x06, 0x01, // global section, 6 bytes, 1 global
+      0x6f, 0x00, // externref, immutable
+      0xd0, 0x6f, 0x0b, // ref.null extern; end
+    ]);
+    return WebAssembly.validate(bytes);
+  } catch {
+    return false;
+  }
+};
+
+export class UnsupportedMediapipeEnvironmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedMediapipeEnvironmentError';
   }
 }
 
@@ -175,6 +215,21 @@ export const getMediapipeInstance = async (): Promise<FaceLandmarker> => {
     return mediapipeGlobal.loading;
   }
 
+  // Fail fast on engines that don't support WebAssembly reftypes/externref.
+  // The MediaPipe Tasks Vision .wasm uses externref globals; instantiating it
+  // on older browsers throws an unhandled `CompileError`. We detect once and
+  // cache the result so callers fall back to the legacy capture flow.
+  if (mediapipeGlobal.supportsWasmReftypes === undefined) {
+    mediapipeGlobal.supportsWasmReftypes = supportsWasmReftypes();
+  }
+  if (!mediapipeGlobal.supportsWasmReftypes) {
+    return Promise.reject(
+      new UnsupportedMediapipeEnvironmentError(
+        'WebAssembly reference types (externref) are not supported in this browser; MediaPipe Tasks Vision cannot be loaded.',
+      ),
+    );
+  }
+
   mediapipeGlobal.loading = (async () => {
     try {
       const vision = await FilesetResolver.forVisionTasks(
@@ -212,4 +267,5 @@ export const getMediapipeInstance = async (): Promise<FaceLandmarker> => {
 export const __testUtils = {
   matchesExcludedGpu,
   getDelegateFromGpuDetection,
+  supportsWasmReftypes,
 };


### PR DESCRIPTION
### **User description**
## Summary

Fixes Sentry [WEB-CLIENT-Q7](https://smile-identity.sentry.io/issues/WEB-CLIENT-Q7) — **5,198 occurrences** of:

```
CompileError: WebAssembly.instantiate(): invalid value type 'externref',
enable with --experimental-wasm-reftypes @+125
```

emitted from the `doc-verification` and `biometric-kyc` bundles.

## Root cause

`@mediapipe/tasks-vision` loads `vision_wasm_internal.wasm` via `FilesetResolver.forVisionTasks(...)` in [`mediapipeManager.ts`](packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts). That `.wasm` module uses the **reference-types proposal** (`externref` value type), which is unsupported on:

- Chrome / Chromium < 96 (Chrome 95 shipped Oct 2021)
- Safari < 15
- Firefox < 79

The Sentry event came from `Chrome Mobile 95` on `Android 5.1` (Oppo A37m), where V8 rejects the module and the error escapes as an unhandled rejection (`mechanism: onunhandledrejection`).

## Fix

- Added a one-time `supportsWasmReftypes()` probe using `WebAssembly.validate` against a minimal module containing an `externref` global.
- Cached the result on `window.__smileIdentityMediapipe.supportsWasmReftypes` so `WebAssembly.validate` is invoked at most once per page.
- `getMediapipeInstance()` short-circuits with a typed `UnsupportedMediapipeEnvironmentError` when reftypes are unavailable — **before** any MediaPipe code runs — so the existing `try/catch` in `SelfieCaptureWrapper.tsx` and `useFaceCapture.ts` cleanly routes affected users to the legacy `selfie-capture` web component instead of bubbling a deep `CompileError` to `window.onunhandledrejection`.

## Tests

New spec `packages/web-components/cypress/e2e/mediapipe-manager-wasm-reftypes.cy.js` — 7 passing tests:

**Probe**
- detects externref support in the current (modern) browser
- returns `false` when `WebAssembly` is unavailable
- returns `false` when `WebAssembly.validate` rejects the externref module
- returns `false` when `WebAssembly.validate` throws

**Fallback**
- rejects with `UnsupportedMediapipeEnvironmentError` when reftypes are unsupported
- does not start MediaPipe loading (`loading` stays `null`, `loaded` stays `false`)
- caches the probe result so `WebAssembly.validate` is invoked exactly once across multiple calls

Existing `mediapipe-manager-gpu.cy.js` still passes (3/3).

## Risk

Low. The new path only triggers on engines that already fail today; the existing happy path is unchanged apart from one cached boolean read.

Closes WEB-CLIENT-Q7


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add WebAssembly reftypes/externref feature probe before MediaPipe loading

- Short-circuit with typed `UnsupportedMediapipeEnvironmentError` on unsupported browsers

- Cache probe result on global to avoid repeated `WebAssembly.validate` calls

- Add Cypress regression tests for probe and fallback behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getMediapipeInstance()"] -- "check cache" --> B["supportsWasmReftypes?"]
  B -- "undefined" --> C["WebAssembly.validate(externref module)"]
  C -- "true" --> D["Load MediaPipe .wasm"]
  C -- "false" --> E["Reject with UnsupportedMediapipeEnvironmentError"]
  E -- "caught by caller" --> F["Legacy selfie-capture fallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediapipeManager.ts</strong><dd><code>Add externref probe and early rejection in MediaPipe manager</code></dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts

<ul><li>Added <code>supportsWasmReftypes()</code> function that validates a minimal <br>externref wasm module<br> <li> Added <code>UnsupportedMediapipeEnvironmentError</code> custom error class<br> <li> Added reftypes check with caching in <code>getMediapipeInstance()</code> before <br>loading MediaPipe<br> <li> Extended <code>__smileIdentityMediapipe</code> global type with <br><code>supportsWasmReftypes</code> field<br> <li> Exported <code>supportsWasmReftypes</code> via <code>__testUtils</code> for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/619/files#diff-0222eb4a7d78c9480736b4ea10961852d9b65869770a18b9792b8d7356c3e447">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediapipe-manager-wasm-reftypes.cy.js</strong><dd><code>Cypress regression tests for reftypes probe and fallback</code>&nbsp; </dd></summary>
<hr>

packages/web-components/cypress/e2e/mediapipe-manager-wasm-reftypes.cy.js

<ul><li>Tests that <code>supportsWasmReftypes()</code> returns true on modern browsers<br> <li> Tests fallback when <code>WebAssembly</code> is unavailable, <code>validate</code> returns <br>false, or throws<br> <li> Tests that <code>getMediapipeInstance</code> rejects with <br><code>UnsupportedMediapipeEnvironmentError</code><br> <li> Tests that the probe result is cached and <code>validate</code> is called at most <br>once</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/619/files#diff-e14719937a8c96e6b567ad8909668902675ac55c302112f307285004180216c0">+189/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>