### PR TITLE
fix(embed): handle fingerprint failures gracefully

### DIFF
--- a/packages/embed/src/js/metadata/fingerprint.js
+++ b/packages/embed/src/js/metadata/fingerprint.js
@@ -1,13 +1,26 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
-const fpPromise = FingerprintJS.load();
+let fpPromise = null;
+try {
+  fpPromise = FingerprintJS.load();
+} catch (error) {
+  console.warn('FingerprintJS failed to load:', error);
+  fpPromise = null;
+}
 
 /**
  * Retrieves a unique identifier for the user's browser, using FingerprintJS.
- * @returns {Promise<string>} A promise that resolves with the visitor ID.
+ * Returns null if fingerprinting fails (e.g., blocked by browser security settings).
+ * @returns {Promise<string|null>} A promise that resolves with the visitor ID, or null on failure.
  */
 export const getFingerprint = async () => {
-  const fp = await fpPromise;
-  const result = await fp.get();
-  return result.visitorId;
+  try {
+    if (!fpPromise) return null;
+    const fp = await fpPromise;
+    const result = await fp.get();
+    return result.visitorId;
+  } catch (error) {
+    console.warn('Failed to get fingerprint:', error);
+    return null;
+  }
 };


### PR DESCRIPTION
### **User description**
## Problem

When FingerprintJS is blocked by browser security settings (e.g., Firefox's Enhanced Tracking Protection blocking `https://openfpcdn.io/fingerprintjs/v4`), the unhandled rejection from `FingerprintJS.load()` / `fp.get()` propagates up through `initializeMetadata`, breaking the rest of metadata collection.

![Firefox blocking openfpcdn.io](https://github.com/user-attachments/assets/placeholder)
> The resource at "https://openfpcdn.io/fingerprintjs/v4" was blocked because Enhanced Tracking Protection is enabled.

## Fix

Wrap both the `FingerprintJS.load()` call and the `getFingerprint()` async logic in try/catch. On failure, return `null` and log a warning. `addMetadataEntry` already skips `null`/`undefined` values, so the rest of the metadata pipeline continues unaffected.

## Changes

- `packages/embed/src/js/metadata/fingerprint.js`: catch load + get errors, return `null` instead of throwing.

## Test plan

- Manually verified flow continues when CDN is blocked (no thrown error in `initializeMetadata`).
- No fingerprint entry is added when blocked; other metadata entries still collected.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle FingerprintJS failures gracefully with try/catch

- Return `null` instead of throwing when blocked

- Prevents metadata initialization from breaking

- Logs warnings when fingerprinting is unavailable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FingerprintJS.load()"] -- "try/catch" --> B["fpPromise or null"]
  B -- "getFingerprint()" --> C["fp.get()"]
  C -- "success" --> D["visitorId"]
  C -- "failure" --> E["null + warning"]
  B -- "null" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fingerprint.js</strong><dd><code>Add error handling for FingerprintJS load and get</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/metadata/fingerprint.js

<ul><li>Wrapped <code>FingerprintJS.load()</code> in a try/catch block, setting <code>fpPromise</code> <br>to <code>null</code> on failure<br> <li> Added try/catch inside <code>getFingerprint()</code> to handle promise rejections<br> <li> Returns <code>null</code> instead of propagating errors when fingerprinting is <br>blocked<br> <li> Added <code>console.warn</code> logging for both load and get failures</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/623/files#diff-fafef3bd548464d3d84247bc26e8cc516eb42c873de11abf5f65f309f00fcce5">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>