### PR TITLE
ci(release): inline web-components publish job for npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,38 @@ jobs:
           fi
           echo "Version verified: $PKG_VERSION"
 
-  publish:
+  test:
     needs: [validate]
+    if: ${{ inputs.skip_tests == false }}
+    uses: ./.github/workflows/test.yml
+
+  publish:
+    needs: [validate, test]
+    if: ${{ always() && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       id-token: write
       contents: read
-    uses: ./.github/workflows/publish-web-components.yml
-    with:
-      skip_tests: ${{ inputs.skip_tests }}
-      skip_validation: true
+    defaults:
+      run:
+        working-directory: ./packages/web-components
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: publish to npm with provenance
+        run: npm publish --provenance --access public
 
   deploy:
     needs: [validate]


### PR DESCRIPTION
### **User description**
## Summary
- Inlines the `publish` job (previously `uses: ./.github/workflows/publish-web-components.yml`) directly into `release.yml`.
- Fixes `npm error 404 Not Found - PUT https://registry.npmjs.org/@smileid%2fweb-components` during trusted-publisher releases.

## Why

Two runs against the same v11.4.2 tag with the trusted-publisher config saved and active:

| Run | Trigger | npm response |
|---|---|---|
| [26195974720](https://github.com/smileidentity/web-client/actions/runs/26195974720) | `release.yml` → `uses: publish-web-components.yml` | **404** (OIDC rejected) |
| [26201533150](https://github.com/smileidentity/web-client/actions/runs/26201533150) | Direct `workflow_dispatch` on `publish-web-components.yml` | **403** "cannot publish over previously published versions: 11.4.2" (OIDC accepted) |

The 403 proves the trusted-publisher config itself is correct. npm's token exchange rejects the OIDC token when the publish job runs via `workflow_call`, so the `job_workflow_ref` claim doesn't match. Inlining the steps puts the job under `release.yml` directly.

`publish-web-components.yml` is intentionally left as-is so it can still be triggered manually under its own trusted-publisher entry.

## Follow-up (manual, outside this PR)

Update the npm trusted-publisher config for `@smileid/web-components`: change **Workflow filename** from `publish-web-components.yml` to `release.yml`.

## Test plan
- [ ] After merging and updating the npm trusted-publisher config, bump `packages/web-components/package.json` to `11.4.3`, tag `v11.4.3`, and run the `release` workflow.
- [ ] Confirm `publish to npm with provenance` exits 0 with `+ @smileid/web-components@11.4.3`.
- [ ] Confirm the new version appears on npmjs.com with a Provenance badge.


___

### **PR Type**
Enhancement


___

### **Description**
- Inline web-components publish job directly into `release.yml`

- Add separate `test` job with conditional skip

- Fix npm OIDC trusted-publisher 404 by matching `job_workflow_ref`

- Configure publish with provenance and public access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  validate["validate job"]
  test["test job (conditional)"]
  publish["publish job (inlined)"]
  deploy["deploy job"]
  validate -- "needs" --> test
  validate -- "needs" --> publish
  test -- "needs" --> publish
  validate -- "needs" --> deploy
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Inline publish steps and add conditional test job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replaced <code>uses: ./.github/workflows/publish-web-components.yml</code> with <br>inline publish steps (checkout, setup node, install, npm publish with <br>provenance)<br> <li> Added a new <code>test</code> job that conditionally runs <br><code>./.github/workflows/test.yml</code> based on <code>skip_tests</code> input<br> <li> Updated <code>publish</code> job to depend on both <code>validate</code> and <code>test</code>, with <code>if: </code><br><code>always() && !failure() && !cancelled()</code><br> <li> Added explicit permissions (<code>id-token: write</code>, <code>contents: read</code>) and <br>working directory for the inlined publish job</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/624/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+28/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>