### PR TITLE
fix(embed): prevent unhandled FingerprintJS load rejections

### DIFF
--- a/packages/embed/src/js/metadata/fingerprint.js
+++ b/packages/embed/src/js/metadata/fingerprint.js
@@ -1,12 +1,9 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
-let fpPromise = null;
-try {
-  fpPromise = FingerprintJS.load();
-} catch (error) {
+const fpPromise = FingerprintJS.load().catch((error) => {
   console.warn('FingerprintJS failed to load:', error);
-  fpPromise = null;
-}
+  return null;
+});
 
 /**
  * Retrieves a unique identifier for the user's browser, using FingerprintJS.
@@ -15,8 +12,9 @@ try {
  */
 export const getFingerprint = async () => {
   try {
-    if (!fpPromise) return null;
     const fp = await fpPromise;
+    if (!fp) return null;
+
     const result = await fp.get();
     return result.visitorId;
   } catch (error) {

--- a/packages/embed/src/js/metadata/fingerprint.js
+++ b/packages/embed/src/js/metadata/fingerprint.js
@@ -1,6 +1,8 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
-const fpPromise = FingerprintJS.load().catch((error) => {
+const fpPromise = FingerprintJS.load({
+  monitoring: false,
+}).catch((error) => {
   console.warn('FingerprintJS failed to load:', error);
   return null;
 });

--- a/packages/embed/src/js/metadata/fingerprint.js
+++ b/packages/embed/src/js/metadata/fingerprint.js
@@ -1,11 +1,11 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
-const fpPromise = FingerprintJS.load({
-  monitoring: false,
-}).catch((error) => {
-  console.warn('FingerprintJS failed to load:', error);
-  return null;
-});
+const fpPromise = Promise.resolve()
+  .then(() => FingerprintJS.load({ monitoring: false }))
+  .catch((error) => {
+    console.warn('FingerprintJS failed to load:', error);
+    return null;
+  });
 
 /**
  * Retrieves a unique identifier for the user's browser, using FingerprintJS.


### PR DESCRIPTION
### **User description**
## Summary
Follow-up to merged PR #623 to address remaining review comments.

## What changed
- Replaced sync `try/catch` around `FingerprintJS.load()` with a Promise-level `.catch(...)`.
- Load failures are now handled immediately at promise creation time, avoiding global `unhandledrejection` noise.
- The load failure path resolves to `null` so subsequent calls don’t keep awaiting a rejected Promise.
- `getFingerprint()` now safely short-circuits when load failed and still returns `null` on any runtime error.

## Why
This directly addresses the two unresolved review threads from #623:
1. Handle asynchronous `FingerprintJS.load()` rejection at source.
2. Avoid repeated awaits on a permanently rejected promise.

## Scope
- `packages/embed/src/js/metadata/fingerprint.js`


___

### **PR Type**
Bug fix


___

### **Description**
- Replace sync try/catch with Promise `.catch()` for FingerprintJS load

- Resolve to `null` on load failure to prevent unhandled rejections

- Short-circuit in `getFingerprint()` when load returned `null`

- Maintain graceful degradation when fingerprinting is blocked


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FingerprintJS.load()"] -- ".catch()" --> B["fpPromise (agent or null)"]
  B -- "await in getFingerprint()" --> C["fp value check"]
  C -- "fp is null" --> D["return null"]
  C -- "fp exists" --> E["fp.get()"]
  E -- "success" --> F["visitorId"]
  E -- "failure (try/catch)" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fingerprint.js</strong><dd><code>Use promise-level catch for FingerprintJS load failures</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/metadata/fingerprint.js

<ul><li>Replaced sync <code>try/catch</code> around <code>FingerprintJS.load()</code> with a <code>.catch()</code> on <br>the returned promise, resolving to <code>null</code> on failure<br> <li> Changed <code>fpPromise</code> from <code>let</code> to <code>const</code> since it's no longer reassigned<br> <li> Moved the null check from <code>fpPromise</code> to the resolved <code>fp</code> value after <br>awaiting<br> <li> Retained inner try/catch in <code>getFingerprint()</code> for runtime errors during <br><code>fp.get()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/626/files#diff-fafef3bd548464d3d84247bc26e8cc516eb42c873de11abf5f65f309f00fcce5">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>