### PR TITLE
feat(embed): add network diagnostics to WASM init failures

### DIFF
--- a/packages/embed/src/js/request.js
+++ b/packages/embed/src/js/request.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser';
+import { fetchWithTimeout } from './fetch-with-retry.js';
 
 const WASM_PATH = 'https://secure.smileidentity.com/web_client_guard_bg.wasm';
 const JS_PATH = 'https://secure.smileidentity.com/web_client_guard.js';
@@ -48,21 +49,36 @@ async function collectFailureDiagnostics() {
 
   let secureOriginReachable = 'unknown';
   let probeError = null;
+  // HEAD on integrity.json: smallest known-good asset on the same origin.
+  // no-store + a fresh query param to bypass any pinned/poisoned cache entry.
+  const probeUrl = `${INTEGRITY_PATH}?probe=${Date.now()}`;
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-    // HEAD on integrity.json: smallest known-good asset on the same origin.
-    // no-store + a fresh query param to bypass any pinned/poisoned cache entry.
-    const probe = await fetch(`${INTEGRITY_PATH}?probe=${Date.now()}`, {
-      method: 'HEAD',
-      cache: 'no-store',
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
+    const probe = await fetchWithTimeout(
+      probeUrl,
+      { method: 'HEAD', cache: 'no-store' },
+      1500,
+    );
     secureOriginReachable = probe.ok ? 'yes' : `status_${probe.status}`;
   } catch (err) {
-    secureOriginReachable = 'no';
     probeError = err && err.message ? err.message : String(err);
+    // Fall back to a no-cors probe. A CORS-stripped WAF 403 rejects the
+    // first probe with TypeError (same shape as a true network failure),
+    // which would falsely tag the origin as unreachable. With no-cors, an
+    // opaque response (status 0) proves the server responded — so we can
+    // distinguish "reachable but CORS/WAF blocking" from "truly unreachable".
+    try {
+      const opaque = await fetchWithTimeout(
+        probeUrl,
+        { method: 'HEAD', cache: 'no-store', mode: 'no-cors' },
+        1500,
+      );
+      secureOriginReachable =
+        opaque.type === 'opaque' || opaque.status === 0
+          ? 'reachable_no_cors'
+          : `status_${opaque.status}`;
+    } catch {
+      secureOriginReachable = 'no';
+    }
   }
 
   return {
@@ -149,7 +165,17 @@ async function initWasm(forceRefetch = false) {
         // Report WASM init failures so we can attribute them. Without this,
         // every signed API call downstream fails opaquely and the user-facing
         // error is something generic like "Failed to get supported ID types".
-        const diagnostics = await collectFailureDiagnostics();
+        // Guard the diagnostics call: if it throws unexpectedly we must
+        // still report the original WASM error rather than swallowing it.
+        let diagnostics = {};
+        try {
+          diagnostics = await collectFailureDiagnostics();
+        } catch (diagErr) {
+          diagnostics = {
+            diagnosticsError:
+              diagErr && diagErr.message ? diagErr.message : String(diagErr),
+          };
+        }
         Sentry.captureException(e, {
           tags: {
             area: 'wasm_init',

--- a/packages/embed/src/js/request.js
+++ b/packages/embed/src/js/request.js
@@ -35,6 +35,47 @@ async function withRetry(fn, label, attempt = 0) {
   }
 }
 
+// Probe whether secure.smileidentity.com is reachable at all from this
+// client, independent of the wasm path that just failed. Helps distinguish
+// "origin unreachable" (DNS / Private Relay / content blocker) from
+// "specific asset / connection-level failure".
+async function collectFailureDiagnostics() {
+  const connection =
+    typeof navigator !== 'undefined' &&
+    (navigator.connection ||
+      navigator.mozConnection ||
+      navigator.webkitConnection);
+
+  let secureOriginReachable = 'unknown';
+  let probeError = null;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    // HEAD on integrity.json: smallest known-good asset on the same origin.
+    // no-store + a fresh query param to bypass any pinned/poisoned cache entry.
+    const probe = await fetch(`${INTEGRITY_PATH}?probe=${Date.now()}`, {
+      method: 'HEAD',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    secureOriginReachable = probe.ok ? 'yes' : `status_${probe.status}`;
+  } catch (err) {
+    secureOriginReachable = 'no';
+    probeError = err && err.message ? err.message : String(err);
+  }
+
+  return {
+    secureOriginReachable,
+    probeError,
+    effectiveType: connection?.effectiveType ?? 'unknown',
+    downlink: connection?.downlink ?? null,
+    rtt: connection?.rtt ?? null,
+    saveData: connection?.saveData ?? null,
+    online: typeof navigator !== 'undefined' ? navigator.onLine : null,
+  };
+}
+
 let wasmInitPromise = null;
 
 async function initWasm(forceRefetch = false) {
@@ -108,8 +149,15 @@ async function initWasm(forceRefetch = false) {
         // Report WASM init failures so we can attribute them. Without this,
         // every signed API call downstream fails opaquely and the user-facing
         // error is something generic like "Failed to get supported ID types".
+        const diagnostics = await collectFailureDiagnostics();
         Sentry.captureException(e, {
-          tags: { area: 'wasm_init', wasmStep: step },
+          tags: {
+            area: 'wasm_init',
+            wasmStep: step,
+            effectiveType: diagnostics.effectiveType,
+            secureOriginReachable: diagnostics.secureOriginReachable,
+          },
+          extra: diagnostics,
         });
         throw e;
       } finally {


### PR DESCRIPTION
### **User description**
## Summary
- Tags Sentry `wasm_init` exceptions with `secureOriginReachable`, `effectiveType`, `rtt`, `downlink`, `navigator.onLine`.
- On failure, probes `secure.smileidentity.com/integrity.json` via HEAD (`cache: 'no-store'`, 3s `AbortController` timeout, fresh `?probe=` query) so we can distinguish:
  - **Origin unreachable** — DNS, Apple Private Relay, content blocker
  - **Asset-specific failure** — WAF 403 stripped of CORS headers (surfaces as opaque `TypeError: Load failed` in Safari)

## Context
Triggered by Sentry issue [WEB-CLIENT-RQ](https://smile-identity.sentry.io/issues/7496969613/) — iOS 18.7 user with `wasm fetch failed after 3 attempts: Load failed`. Investigation found `AWS-AWSManagedRulesAmazonIpReputationList` on CloudFront `EDU5EPZYZJFT1` blocking real users on the same paths (`get-sampled-requests` showed 6 blocks in 3h matching the pattern exactly). That rule has since been flipped to `Count`; this PR adds the observability so the next opaque fetch failure is diagnosable from Sentry alone instead of needing AWS access.

Probe only runs on the failure path — zero overhead on the happy path.

## Test plan
- [ ] Force a wasm fetch failure locally (e.g. block `secure.smileidentity.com` in DevTools) and confirm Sentry event includes the new tags + extras.
- [ ] Confirm happy path is unchanged (no extra requests in the network panel).
- [ ] Verify `secureOriginReachable` reports `"no"` when the whole origin is blocked, `"status_403"` when only the wasm/integrity paths 403, `"yes"` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add network diagnostics probe on WASM init failure

- Tag Sentry exceptions with connectivity and reachability info

- Probe `secure.smileidentity.com/integrity.json` to distinguish failure causes

- Zero overhead on happy path; diagnostics only on failure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WASM init fails"] -- "triggers" --> B["collectFailureDiagnostics()"]
  B -- "HEAD request" --> C["integrity.json probe"]
  C -- "reachable" --> D["secureOriginReachable: yes/status_N"]
  C -- "unreachable" --> E["secureOriginReachable: no"]
  B -- "collects" --> F["Network Info API data"]
  D --> G["Sentry.captureException with tags + extras"]
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>request.js</strong><dd><code>Add failure diagnostics probe and enrich Sentry context</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/src/js/request.js

<ul><li>Added <code>collectFailureDiagnostics()</code> function that probes <br><code>secure.smileidentity.com/integrity.json</code> via HEAD with a 3s timeout and <br><code>cache: 'no-store'</code><br> <li> Collects Network Information API data (<code>effectiveType</code>, <code>downlink</code>, <code>rtt</code>, <br><code>saveData</code>) and <code>navigator.onLine</code><br> <li> Invoked in the WASM init catch block; results attached to Sentry as <br>tags (<code>effectiveType</code>, <code>secureOriginReachable</code>) and extras (full <br>diagnostics object)</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/627/files#diff-082025035f3eb04389450b92c1cfcf640a863fc3643a5940875dcd593115dcf0">+49/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>