### PR TITLE
fix(mediapipe): force CPU delegate on Firefox to avoid ml_drift WebGL…

### DIFF
--- a/packages/web-components/cypress/e2e/mediapipe-manager-gpu.cy.js
+++ b/packages/web-components/cypress/e2e/mediapipe-manager-gpu.cy.js
@@ -83,4 +83,36 @@ describe('MediaPipe Manager GPU detection', () => {
       }
     });
   });
+
+  it('uses CPU on Firefox regardless of GPU capabilities', () => {
+    cy.visit('/');
+
+    cy.window().then(async (win) => {
+      const mod = await importManager(win);
+      const userAgentDescriptor = Object.getOwnPropertyDescriptor(
+        win.navigator,
+        'userAgent',
+      );
+
+      try {
+        Object.defineProperty(win.navigator, 'userAgent', {
+          configurable: true,
+          value:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0',
+        });
+
+        expect(mod.__testUtils.isFirefox()).to.equal(true);
+        const delegate = await mod.__testUtils.getDelegateFromGpuDetection();
+        expect(delegate).to.equal('CPU');
+      } finally {
+        if (userAgentDescriptor) {
+          Object.defineProperty(
+            win.navigator,
+            'userAgent',
+            userAgentDescriptor,
+          );
+        }
+      }
+    });
+  });
 });

--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts
@@ -123,6 +123,25 @@ export class UnsupportedMediapipeEnvironmentError extends Error {
 }
 
 /**
+ * @description Detects Firefox via user agent. MediaPipe's ml_drift gl30
+ * WebGL inference backend trips a kernel-argument mismatch on Firefox
+ * (e.g. `No float with name - src_tensor_sub_tex_width` from
+ * `gl_arguments_obfuscated.cc`), causing the FaceLandmarker graph to fail on
+ * every frame. Firefox also masks `WEBGL_debug_renderer_info` and does not
+ * implement `navigator.userAgentData`, so neither of the existing detection
+ * paths can identify the broken environment. Forcing the CPU delegate moves
+ * inference to XNNPACK and avoids the crash. See google-ai-edge/mediapipe
+ * issues #5666 and #5879.
+ * @returns {boolean} True when the runtime is Firefox.
+ */
+const isFirefox = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  // Match Firefox desktop, Firefox iOS (FxiOS) and Firefox Android (Fennec).
+  return /firefox|fxios/i.test(ua);
+};
+
+/**
  * @description Reads system architecture hints from User-Agent Client Hints.
  * @returns {Promise<string | null>} Lower-cased hint string or null when hints are unavailable.
  */
@@ -153,6 +172,13 @@ const getSystemArchitectureHints = async (): Promise<string | null> => {
  * @returns {Promise<'CPU' | 'GPU'>} CPU when excluded GPU is detected; otherwise GPU.
  */
 const getDelegateFromGpuDetection = async (): Promise<'CPU' | 'GPU'> => {
+  // Firefox: ml_drift WebGL backend crashes on every frame regardless of GPU.
+  // Force CPU before any other detection so we never reach the GPU delegate.
+  if (isFirefox()) {
+    console.info('[SmileID] Firefox detected. Using CPU delegate.');
+    return 'CPU';
+  }
+
   const renderer = getGpuRenderer();
   const hasWebGlRendererInfo = !!renderer;
 
@@ -277,4 +303,5 @@ export const __testUtils = {
   matchesExcludedGpu,
   getDelegateFromGpuDetection,
   supportsWasmReftypes,
+  isFirefox,
 };


### PR DESCRIPTION
### **User description**
… crash

Firefox's MediaPipe Tasks Vision GPU path crashes inside the ml_drift gl30 backend with errors like 'No float with name - src_tensor_sub_tex_width' / 'No int with name - dst_tensor_height' from gl_arguments_obfuscated.cc, causing FaceLandmarker to fail on every frame in the smart-selfie capture flow.

The existing GPU exclusion list (Adreno) cannot catch this because Firefox masks WEBGL_debug_renderer_info on macOS and does not implement navigator.userAgentData, so neither detection path identifies the broken environment. The runtime then passes the FP16 gate (Apple Silicon supports the half-float extensions) and selects the GPU delegate.

Add an isFirefox() UA check that short-circuits getDelegateFromGpuDetection to CPU. CPU runs inference on XNNPACK and avoids the broken WebGL kernel. Refs google-ai-edge/mediapipe#5666 and #5879.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Force CPU delegate on Firefox to avoid MediaPipe WebGL crash

- Add `isFirefox()` UA check short-circuiting GPU detection

- Add Cypress test verifying Firefox falls back to CPU


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getDelegateFromGpuDetection()"] -- "first check" --> B["isFirefox()"]
  B -- "true" --> C["Return CPU delegate"]
  B -- "false" --> D["Existing GPU detection logic"]
  D --> E["Return CPU or GPU"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediapipe-manager-gpu.cy.js</strong><dd><code>Add Cypress test for Firefox CPU fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/cypress/e2e/mediapipe-manager-gpu.cy.js

<ul><li>Added a new Cypress test that spoofs a Firefox user agent string<br> <li> Verifies <code>isFirefox()</code> returns true and <code>getDelegateFromGpuDetection()</code> <br>returns <code>'CPU'</code><br> <li> Properly restores the original <code>userAgent</code> descriptor in a finally block</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/634/files#diff-a144c2b3a196aa5abbc77301c42c9587b51c1d410fd2362915654caadf02e7be">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediapipeManager.ts</strong><dd><code>Force CPU delegate when Firefox is detected</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/smartselfie-capture/utils/mediapipeManager.ts

<ul><li>Added <code>isFirefox()</code> helper that detects Firefox (desktop, iOS, Android) <br>via user agent regex<br> <li> Short-circuits <code>getDelegateFromGpuDetection()</code> to return <code>'CPU'</code> when <br>Firefox is detected<br> <li> Logs an informational message when Firefox fallback is triggered<br> <li> Exported <code>isFirefox</code> via <code>__testUtils</code> for test access</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/634/files#diff-0222eb4a7d78c9480736b4ea10961852d9b65869770a18b9792b8d7356c3e447">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>