### PR TITLE
fix(selfie): separate cosmetic countdown from load deadline

### DIFF
--- a/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import { IconLoader2 } from '@tabler/icons-preact';
 import register from 'preact-custom-element';
 import type { FunctionComponent } from 'preact';
@@ -45,8 +45,15 @@ interface Props {
   hidden?: string | boolean;
 }
 
-const DEFAULT_MEDIAPIPE_WAIT_MS = 90 * 1000; // For when legacy fallback is NOT allowed, we wait the full 90s for mediapipe to load before showing an error.
-const DEFAULT_WAIT_MS = 20 * 1000; // default for when legacy fallback is allowed we wait for 20s
+// Default deadlines for the Mediapipe load attempt. These are used when the
+// host did NOT provide an explicit `timeout` prop; an explicit `timeout`
+// always wins regardless of the legacy-fallback flag.
+//   - With legacy fallback allowed: 20s, so users on broken networks get a
+//     usable capture quickly.
+//   - Without legacy fallback: 90s, so we keep waiting before giving up to
+//     the error UI.
+const DEFAULT_MEDIAPIPE_WAIT_MS = 90 * 1000;
+const DEFAULT_WAIT_MS = 20 * 1000;
 // Cap retries on transient init failures so we don't spin forever, while still
 // allowing recovery from short-lived issues (e.g. CDN hiccups while the
 // wrapper is preloading in a hidden state). Retries are spaced with
@@ -58,7 +65,7 @@ const MEDIAPIPE_RETRY_BASE_DELAY_MS = 500;
 // SmartSelfieCapture (Mediapipe-based) or fallback to the legacy `selfie-capture`
 // web component after a timeout (default 90 seconds).
 const SelfieCaptureWrapper: FunctionComponent<Props> = ({
-  timeout = DEFAULT_MEDIAPIPE_WAIT_MS,
+  timeout,
   'start-countdown': startCountdownProp = false,
   'allow-legacy-selfie-fallback': allowLegacySelfieFallbackProp = false,
   hidden: hiddenProp = false,
@@ -85,26 +92,51 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
   const hidden = getBoolProp(hiddenProp);
   const startCountdown = getBoolProp(startCountdownProp);
   const allowLegacySelfieFallback = getBoolProp(allowLegacySelfieFallbackProp);
-  const loadingTime = allowLegacySelfieFallback ? DEFAULT_WAIT_MS : timeout;
+
+  // Resolve how long we'll wait for Mediapipe before the hard deadline fires.
+  // Precedence:
+  //   1. Explicit `timeout` prop (parsed defensively because web component
+  //      attributes arrive as strings).
+  //   2. With legacy fallback allowed: DEFAULT_WAIT_MS (20s).
+  //   3. Otherwise: DEFAULT_MEDIAPIPE_WAIT_MS (90s).
+  const parsedTimeout =
+    typeof timeout === 'string' ? Number(timeout) : timeout;
+  const hasExplicitTimeout =
+    typeof parsedTimeout === 'number' &&
+    Number.isFinite(parsedTimeout) &&
+    parsedTimeout > 0;
+  const loadingTime = hasExplicitTimeout
+    ? (parsedTimeout as number)
+    : allowLegacySelfieFallback
+      ? DEFAULT_WAIT_MS
+      : DEFAULT_MEDIAPIPE_WAIT_MS;
 
   // Component state:
   // - mediapipeReady: whether the mediapipe instance has successfully loaded
-  // - loadingProgress: percentage used for the visible loading UI
+  // - loadingProgress: percentage used for the visible loading UI (cosmetic)
+  // - loadDeadlineExceeded: hard cap signal — once true, we stop waiting for
+  //   Mediapipe and commit to the legacy fallback (or error UI). Kept
+  //   separate from `loadingProgress` so the decision is driven by a single
+  //   setTimeout firing once, not by a 200ms ticking interval that can race
+  //   with the Mediapipe promise resolution.
   // - initialSessionCompleted: set when the legacy component emits publish/cancel/close
   // - mediapipeLoading: true while attempting to load mediapipe
   // - usingSelfieCapture: whether we've mounted the legacy `selfie-capture` element
   const [mediapipeReady, setMediapipeReady] = useState(false);
   const [loadingProgress, setLoadingProgress] = useState(isCypress ? 100 : 0);
+  const [loadDeadlineExceeded, setLoadDeadlineExceeded] = useState(isCypress);
   const [initialSessionCompleted, setInitialSessionCompleted] = useState(false);
   const [mediapipeLoading, setMediapipeLoading] = useState(false);
   // `unsupportedEnvironment` is a permanent, one-shot signal: we know
   // MediaPipe cannot run here, so stop trying.
   const [unsupportedEnvironment, setUnsupportedEnvironment] = useState(false);
-  // Bounded retry counter for transient init failures.
-  const [mediapipeInitAttempts, setMediapipeInitAttempts] = useState(0);
+  // Bounded retry counter for transient init failures. Stored in a ref so
+  // incrementing it does not trigger a re-render — it's only read inside the
+  // load effect.
+  const mediapipeInitAttemptsRef = useRef(0);
   // Dedup flag so we only report a given init failure to Sentry once per
-  // wrapper instance, even if we end up retrying.
-  const [mediapipeInitReported, setMediapipeInitReported] = useState(false);
+  // wrapper instance, even if we end up retrying. Ref for the same reason.
+  const mediapipeInitReportedRef = useRef(false);
   const [usingSelfieCapture, setUsingSelfieCapture] = useState(false);
 
   // Attempt to load Mediapipe (with a small bounded retry budget). If
@@ -117,7 +149,7 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
       mediapipeReady ||
       mediapipeLoading ||
       unsupportedEnvironment ||
-      mediapipeInitAttempts >= MAX_MEDIAPIPE_INIT_ATTEMPTS ||
+      mediapipeInitAttemptsRef.current >= MAX_MEDIAPIPE_INIT_ATTEMPTS ||
       isCypress
     )
       return undefined;
@@ -127,8 +159,8 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
 
     const loadMediapipe = async () => {
       setMediapipeLoading(true);
-      const attemptNumber = mediapipeInitAttempts + 1;
-      setMediapipeInitAttempts(attemptNumber);
+      const attemptNumber = mediapipeInitAttemptsRef.current + 1;
+      mediapipeInitAttemptsRef.current = attemptNumber;
       try {
         await getMediapipeInstance();
         if (cancelled) return;
@@ -145,8 +177,8 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
         // Report to Sentry (when the host page has exposed it on window) so we
         // can observe how often users land on the fallback path and which
         // environments are affected. Dedup so retries don't flood Sentry.
-        if (!mediapipeInitReported) {
-          setMediapipeInitReported(true);
+        if (!mediapipeInitReportedRef.current) {
+          mediapipeInitReportedRef.current = true;
           window.Sentry?.captureException(error, {
             tags: {
               area: 'mediapipe_init',
@@ -164,6 +196,7 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
         if (isUnsupportedEnvironment) {
           setUnsupportedEnvironment(true);
           setLoadingProgress(100);
+          setLoadDeadlineExceeded(true);
           setMediapipeLoading(false);
           return;
         }
@@ -198,15 +231,20 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
     mediapipeReady,
     mediapipeLoading,
     unsupportedEnvironment,
-    mediapipeInitAttempts,
-    mediapipeInitReported,
   ]);
 
-  // When using the loading countdown (startCountdown), increment the
-  // visible loading progress. This is only used while mediapipe hasn't
-  // reported ready; once mediapipeReady becomes true we stop the timer.
+  // Cosmetic loading progress: ticks 0→100 over `loadingTime` so the UI can
+  // show "slow connection" copy past the SLOW_CONNECTION_THRESHOLD. This is
+  // purely visual — it does NOT decide when we fall back. The decision is
+  // driven by `loadDeadlineExceeded` below.
   useEffect(() => {
-    if (hidden || !startCountdown || mediapipeReady) return undefined;
+    if (
+      hidden ||
+      !startCountdown ||
+      mediapipeReady ||
+      loadingProgress >= 100
+    )
+      return undefined;
 
     const timer = setInterval(() => {
       setLoadingProgress((prev: number) => Math.min(prev + 1, 100));
@@ -215,10 +253,45 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
     return () => {
       clearInterval(timer);
     };
-  }, [hidden, startCountdown, loadingTime, mediapipeReady]);
+  }, [hidden, startCountdown, loadingTime, mediapipeReady, loadingProgress]);
+
+  // Hard deadline: a single setTimeout that flips `loadDeadlineExceeded`
+  // exactly once. This is the signal the render path uses to commit to the
+  // fallback. Skipped when hidden, when Mediapipe is already ready, or under
+  // Cypress (where the flag is pre-seeded to true).
+  useEffect(() => {
+    if (hidden || mediapipeReady || loadDeadlineExceeded || isCypress)
+      return undefined;
+
+    const id = setTimeout(() => {
+      setLoadDeadlineExceeded(true);
+    }, loadingTime);
+
+    return () => clearTimeout(id);
+  }, [hidden, mediapipeReady, loadDeadlineExceeded, loadingTime, isCypress]);
+
+  // Latch the legacy fallback decision in an effect rather than during
+  // render. Effects only run after commit, so by the time this runs, any
+  // Mediapipe-ready update scheduled in the same batch as the deadline tick
+  // will already be visible — closing the race where `setLoadDeadlineExceeded`
+  // and `setMediapipeReady` fire in adjacent microtasks.
+  useEffect(() => {
+    if (hidden || usingSelfieCapture || mediapipeReady) return;
+    if (!loadDeadlineExceeded) return;
+    const legacyFallbackAllowed = allowLegacySelfieFallback || isCypress;
+    if (!legacyFallbackAllowed) return;
+    setUsingSelfieCapture(true);
+  }, [
+    hidden,
+    usingSelfieCapture,
+    mediapipeReady,
+    loadDeadlineExceeded,
+    allowLegacySelfieFallback,
+    isCypress,
+  ]);
 
   useEffect(() => {
-    if (hidden || mediapipeReady || loadingProgress < 100) return undefined;
+    if (hidden || mediapipeReady || !loadDeadlineExceeded) return undefined;
 
     const setupEventForwarding = () => {
       const selfieCapture = document.querySelector('selfie-capture');
@@ -267,7 +340,7 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [hidden, mediapipeReady, loadingProgress]);
+  }, [hidden, mediapipeReady, loadDeadlineExceeded]);
 
   // Dispatch allow_legacy_selfie_fallback config for observability
   useEffect(() => {
@@ -312,60 +385,55 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
     return <SmartSelfieCapture {...props} />;
   }
 
-  if (loadingProgress >= 100) {
-    // When loading completes without Mediapipe becoming ready, check if legacy
-    // fallback is allowed. Legacy is allowed if:
-    // 1. allow-legacy-selfie-fallback attribute is set to true, OR
-    // 2. Running under Cypress (to keep existing test behavior)
-    const legacyFallbackAllowed = allowLegacySelfieFallback || isCypress;
+  // Legacy capture is mounted only once the latch effect has set
+  // `usingSelfieCapture`. The effect re-checks `mediapipeReady` after commit,
+  // so if Mediapipe became ready in the same batch as the deadline tick, the
+  // latch is skipped and the SmartSelfie branch above wins. While we're
+  // waiting for the effect to fire (a single microtask), keep showing the
+  // spinner instead of flashing legacy.
+  if (usingSelfieCapture) {
+    const propsWithoutHidden = { ...props };
+    delete (propsWithoutHidden as any).hidden;
 
-    if (legacyFallbackAllowed) {
-      // Mount the legacy `selfie-capture` web component. We also set
-      // `usingSelfieCapture` so other effects can react (e.g. metadata dispatch).
-      if (!usingSelfieCapture) {
-        setUsingSelfieCapture(true);
-      }
+    return (
+      // @ts-expect-error --- preact-custom-element doesn't have proper types for refs
+      <selfie-capture
+        {...propsWithoutHidden}
+        ref={(el: HTMLElement) => {
+          if (el && !el.hasAttribute('data-events-setup')) {
+            el.setAttribute('data-events-setup', 'true');
 
-      const propsWithoutHidden = { ...props };
-      delete (propsWithoutHidden as any).hidden;
+            const forwardEvent = (event: Event) => {
+              const customEvent = event as CustomEvent;
 
-      return (
-        // @ts-expect-error --- preact-custom-element doesn't have proper types for refs
-        <selfie-capture
-          {...propsWithoutHidden}
-          ref={(el: HTMLElement) => {
-            if (el && !el.hasAttribute('data-events-setup')) {
-              el.setAttribute('data-events-setup', 'true');
+              if (
+                customEvent.type === 'selfie-capture.publish' ||
+                customEvent.type === 'selfie-capture.cancelled' ||
+                customEvent.type === 'selfie-capture.close'
+              ) {
+                setInitialSessionCompleted(true);
+              }
 
-              const forwardEvent = (event: Event) => {
-                const customEvent = event as CustomEvent;
+              window.dispatchEvent(
+                new CustomEvent(customEvent.type, {
+                  detail: customEvent.detail,
+                  bubbles: true,
+                }),
+              );
+            };
 
-                if (
-                  customEvent.type === 'selfie-capture.publish' ||
-                  customEvent.type === 'selfie-capture.cancelled' ||
-                  customEvent.type === 'selfie-capture.close'
-                ) {
-                  setInitialSessionCompleted(true);
-                }
+            el.addEventListener('selfie-capture.publish', forwardEvent);
+            el.addEventListener('selfie-capture.cancelled', forwardEvent);
+            el.addEventListener('selfie-capture.close', forwardEvent);
+          }
+        }}
+      />
+    );
+  }
 
-                window.dispatchEvent(
-                  new CustomEvent(customEvent.type, {
-                    detail: customEvent.detail,
-                    bubbles: true,
-                  }),
-                );
-              };
-
-              el.addEventListener('selfie-capture.publish', forwardEvent);
-              el.addEventListener('selfie-capture.cancelled', forwardEvent);
-              el.addEventListener('selfie-capture.close', forwardEvent);
-            }
-          }}
-        />
-      );
-    }
-
-    // Legacy fallback is NOT allowed: show error message
+  // Hard deadline elapsed and legacy fallback isn't allowed: show the
+  // connection error.
+  if (loadDeadlineExceeded && !(allowLegacySelfieFallback || isCypress)) {
     return (
       <div style={{ textAlign: 'center', marginTop: '20%', padding: '0 20px' }}>
         <p style={{ fontSize: '1.2rem', color: '#333' }}>

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
@@ -30,7 +30,7 @@ declare global {
 }
 
 interface Props {
-  timeout?: number;
+  timeout?: string | number;
   interval?: number;
   duration?: number;
   'theme-color'?: string;

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
@@ -104,11 +104,12 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
     typeof parsedTimeout === 'number' &&
     Number.isFinite(parsedTimeout) &&
     parsedTimeout > 0;
+  const defaultLoadingTime = allowLegacySelfieFallback
+    ? DEFAULT_WAIT_MS
+    : DEFAULT_MEDIAPIPE_WAIT_MS;
   const loadingTime = hasExplicitTimeout
     ? (parsedTimeout as number)
-    : allowLegacySelfieFallback
-      ? DEFAULT_WAIT_MS
-      : DEFAULT_MEDIAPIPE_WAIT_MS;
+    : defaultLoadingTime;
 
   // Component state:
   // - mediapipeReady: whether the mediapipe instance has successfully loaded

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
@@ -99,8 +99,7 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
   //      attributes arrive as strings).
   //   2. With legacy fallback allowed: DEFAULT_WAIT_MS (20s).
   //   3. Otherwise: DEFAULT_MEDIAPIPE_WAIT_MS (90s).
-  const parsedTimeout =
-    typeof timeout === 'string' ? Number(timeout) : timeout;
+  const parsedTimeout = typeof timeout === 'string' ? Number(timeout) : timeout;
   const hasExplicitTimeout =
     typeof parsedTimeout === 'number' &&
     Number.isFinite(parsedTimeout) &&
@@ -227,23 +226,14 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
         clearTimeout(retryTimeoutId);
       }
     };
-  }, [
-    mediapipeReady,
-    mediapipeLoading,
-    unsupportedEnvironment,
-  ]);
+  }, [mediapipeReady, mediapipeLoading, unsupportedEnvironment]);
 
   // Cosmetic loading progress: ticks 0→100 over `loadingTime` so the UI can
   // show "slow connection" copy past the SLOW_CONNECTION_THRESHOLD. This is
   // purely visual — it does NOT decide when we fall back. The decision is
   // driven by `loadDeadlineExceeded` below.
   useEffect(() => {
-    if (
-      hidden ||
-      !startCountdown ||
-      mediapipeReady ||
-      loadingProgress >= 100
-    )
+    if (hidden || !startCountdown || mediapipeReady || loadingProgress >= 100)
       return undefined;
 
     const timer = setInterval(() => {

--- a/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
+++ b/packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx
@@ -234,17 +234,22 @@ const SelfieCaptureWrapper: FunctionComponent<Props> = ({
   // purely visual — it does NOT decide when we fall back. The decision is
   // driven by `loadDeadlineExceeded` below.
   useEffect(() => {
-    if (hidden || !startCountdown || mediapipeReady || loadingProgress >= 100)
-      return undefined;
+    if (hidden || !startCountdown || mediapipeReady) return undefined;
 
     const timer = setInterval(() => {
-      setLoadingProgress((prev: number) => Math.min(prev + 1, 100));
+      setLoadingProgress((prev: number) => {
+        if (prev >= 100) {
+          clearInterval(timer);
+          return 100;
+        }
+        return prev + 1;
+      });
     }, loadingTime / 100);
 
     return () => {
       clearInterval(timer);
     };
-  }, [hidden, startCountdown, loadingTime, mediapipeReady, loadingProgress]);
+  }, [hidden, startCountdown, loadingTime, mediapipeReady]);
 
   // Hard deadline: a single setTimeout that flips `loadDeadlineExceeded`
   // exactly once. This is the signal the render path uses to commit to the


### PR DESCRIPTION
### **User description**
## Summary

Decouples the visible loading-progress counter from the legacy-fallback decision in `<selfie-capture-wrapper>` to fix a race where MediaPipe could resolve at roughly the same instant the countdown hit 100%, causing the wrapper to commit to the legacy capture even though the modern `SmartSelfieCapture` was ready.

## What changed

- **Timeout precedence (new):**
  1. Explicit `timeout` prop (parsed defensively — custom-element attrs arrive as strings).
  2. With `allow-legacy-selfie-fallback`: `DEFAULT_WAIT_MS` (20s).
  3. Otherwise: `DEFAULT_MEDIAPIPE_WAIT_MS` (90s).
- **Two-signal architecture:**
  - `loadingProgress` (cosmetic) still ticks 0→100 over `loadingTime`, so the 44% slow-connection copy keeps firing at the same point.
  - `loadDeadlineExceeded` (new) is set once by a single `setTimeout` and is the only signal that drives the fallback decision.
- **Latch moved into a `useEffect`:** `setUsingSelfieCapture(true)` now runs after commit instead of during render, so a same-batch `setMediapipeReady(true)` is visible when the latch decides — closing the race.
- **Legacy mount is now gated on `usingSelfieCapture`** (set by the latch effect), not on `loadDeadlineExceeded`. While the effect is pending we keep the spinner instead of flashing legacy.
- **Unsupported-environment branch** now also flips `loadDeadlineExceeded` so the wrapper short-circuits to the fallback decision immediately instead of leaving the spinner up for the rest of the countdown.
- **Retry bookkeeping → refs:** `mediapipeInitAttempts` and `mediapipeInitReported` are refs instead of state, so they don't churn effect deps or trigger pointless re-renders.

## Behaviour matrix

| State | Render |
| --- | --- |
| `hidden` | `null` |
| `mediapipeReady && !usingSelfieCapture` | `SmartSelfieCapture` (covers initial + retake) |
| `usingSelfieCapture` (latched) | legacy `<selfie-capture>` |
| `loadDeadlineExceeded` and no legacy path | connection-error UI |
| otherwise | spinner (with slow-connection copy past 44%) |

The latch is sticky once set, so the user is never switched mid-capture.

## Test plan

- [ ] Local Cypress run in `packages/web-components` (legacy-fallback tests still pass with `loadDeadlineExceeded` pre-seeded under Cypress).
- [ ] Manual: throttled network, `allow-legacy-selfie-fallback="true"`, no explicit `timeout` → confirm legacy mounts at ~20s.
- [ ] Manual: throttled network, no `allow-legacy-selfie-fallback` → confirm we keep waiting up to 90s before the error UI.
- [ ] Manual: explicit `timeout="45000"` with legacy allowed → confirm fallback at 45s, not 20s.
- [ ] Manual: MediaPipe resolves at ~99% progress → confirm `SmartSelfieCapture` wins (no legacy flash).

Draft while the manual verification is being done.


___

### **PR Type**
Bug fix


___

### **Description**
- Separate cosmetic countdown from load deadline decision

- Add `loadDeadlineExceeded` flag via single `setTimeout`

- Move legacy fallback latch into a `useEffect` to close race

- Convert retry bookkeeping state to refs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["loadingProgress (cosmetic)"] -- "ticks 0→100" --> B["UI slow-connection copy"]
  C["setTimeout (loadingTime)"] -- "fires once" --> D["loadDeadlineExceeded"]
  D -- "checked in effect" --> E["usingSelfieCapture latch"]
  E -- "gates render" --> F["Legacy selfie-capture"]
  G["mediapipeReady"] -- "wins if same batch" --> H["SmartSelfieCapture"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelfieCaptureWrapper.tsx</strong><dd><code>Decouple deadline signal from cosmetic progress counter</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/selfie-capture-wrapper/SelfieCaptureWrapper.tsx

<ul><li>Added <code>loadDeadlineExceeded</code> state driven by a single <code>setTimeout</code> to <br>replace the <code>loadingProgress >= 100</code> check for fallback decisions<br> <li> Moved <code>usingSelfieCapture</code> latch logic from render-time into a dedicated <br><code>useEffect</code> that runs post-commit, closing the race with <br><code>setMediapipeReady</code><br> <li> Converted <code>mediapipeInitAttempts</code> and <code>mediapipeInitReported</code> from state <br>to refs to avoid unnecessary re-renders and effect dep churn<br> <li> Resolved <code>timeout</code> prop with explicit precedence: explicit prop > <br><code>DEFAULT_WAIT_MS</code> (legacy allowed) > <code>DEFAULT_MEDIAPIPE_WAIT_MS</code> (no <br>legacy), with defensive string parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/638/files#diff-ed7abde777be601b5ebcb35ce5e55116b09651894cc5c0eed58eb1fdeaba56b7">+140/-81</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>