### PR TITLE
fix: selfie capture stalls when face leaves neutral zone before first capture

### DIFF
--- a/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
+++ b/packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts
@@ -336,6 +336,17 @@ export const useFaceCapture = ({
             }, 0);
           }
         }
+
+        // Before the smile zone, resume automatically when face returns to a
+        // valid position — no smile is needed yet.
+        if (
+          isPaused.value &&
+          isCapturing.value &&
+          capturesTaken.value < smileCheckpoint.value &&
+          resumeCaptureRef.current
+        ) {
+          resumeCaptureRef.current();
+        }
       } else {
         // No face detected - reset values
         currentSmileScore.value = 0;


### PR DESCRIPTION
### **User description**
## Summary

- When a selfie capture was paused (face left bounds or wrong proximity) before reaching the smile zone, `resumeCapture()` was only ever triggered by smile detection — leaving the capture permanently stalled with the UI showing "capturing" but taking no frames
- Added an auto-resume path in `detectFace`: when capture is paused and `capturesTaken < smileCheckpoint`, call `resumeCapture()` as soon as the face returns to a valid state
- The smile zone is unaffected — the `capturesTaken >= smileCheckpoint` guard keeps the existing smile-triggered resume exclusive to that phase

## Root cause

`resumeCapture()` was only called from the smile detection block in `detectFace`. For the neutral and middle zones no smile is required, so a paused capture could never self-recover when the face returned to a valid position.

## Test plan

- [ ] Click capture, move close enough to enter "capturing" state, then briefly move too far/out of bounds and back in — capture should resume automatically without needing to smile
- [ ] Verify smile zone is unchanged: once in the smile zone, capture should still pause and wait for a smile before resuming
- [ ] Run `pnpm --filter @smile-id/web-components tsc --noEmit` — no type errors
- [ ] Run existing Cypress suite — all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Auto-resume selfie capture in pre-smile zone when face returns to valid position

- Previously, capture stalled permanently if face left bounds before smile checkpoint

- `resumeCapture()` now called when paused and `capturesTaken < smileCheckpoint`

- Smile zone behavior remains unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Face leaves valid zone"] -- "capture paused" --> B["isPaused = true"]
  B -- "face returns, capturesTaken < smileCheckpoint" --> C["resumeCapture() called"]
  B -- "face returns, capturesTaken >= smileCheckpoint" --> D["Wait for smile to resume"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useFaceCapture.ts</strong><dd><code>Add auto-resume path for pre-smile-zone captures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/selfie/src/smartselfie-capture/hooks/useFaceCapture.ts

<ul><li>Added auto-resume logic after the smile detection block in <code>detectFace</code><br> <li> When <code>isPaused</code>, <code>isCapturing</code>, and <code>capturesTaken < smileCheckpoint</code>, calls <br><code>resumeCaptureRef.current()</code> to restart capture without requiring a <br>smile</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/653/files#diff-ac8fe68b6164d1778c63c6a896ef6b97cabf43d7b262f9d6f973edca5c800b02">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>