### PR TITLE
chore: note selfie capture auto-resume fix in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Selfie: auto-resume capture when the face returns to a valid zone before the smile checkpoint, so the flow no longer stalls in a "capturing" state without taking frames
+
 ## [11.4.5] - 2026-06-09
 
 ### Changed


### PR DESCRIPTION
### **User description**
## Summary

Adds a `[Unreleased]` entry to `CHANGELOG.md` documenting the latest selfie capture loading fix, which auto-resumes capture when the face returns to a valid zone before the smile checkpoint so the flow no longer stalls in a "capturing" state without taking frames.

## Changes

- Add a `Changed` entry under `[Unreleased]` in `CHANGELOG.md`.


___

### **PR Type**
Documentation


___

### **Description**
- Add changelog entry for selfie capture auto-resume fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Selfie capture fix"] -- "documented in" --> B["CHANGELOG.md [Unreleased]"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document selfie auto-resume fix in unreleased section</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added a <code>### Changed</code> section under <code>[Unreleased]</code> documenting the selfie <br>capture auto-resume fix that prevents the flow from stalling before <br>the smile checkpoint.</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/655/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>