### PR TITLE
docs(embed,web-components): document strict mode for enhanced smartselfie

### DIFF
--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -109,27 +109,25 @@ When you're ready to create a new release for this project, follow the steps bel
 
 The embed supports several configuration options:
 
-| Option                         | Type      | Default | Description                                                                                                                                                          |
-| ------------------------------ | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `hide_attribution`             | `boolean` | `false` | Hide Smile ID attribution/credits                                                                                                                                    |
-| `allow_agent_mode`             | `boolean` | `false` | Allow agent mode for assisted capture                                                                                                                                |
-| `use_strict_mode`              | `boolean` | `false` | Enables Enhanced SmartSelfie capture behavior. Set to `true` to enable strict-mode selfie capture.                                                                   |
-| `allow_legacy_selfie_fallback` | `boolean` | `false` | Allow fallback to legacy selfie capture if Mediapipe fails to load. When `false` (default), an error message is shown instead of falling back to the legacy capture. |
-| `id_info`                      | `object`  | —       | Pre-fill ID information fields. Keys are country codes mapping to ID types and field data. See [Pre-filled ID Inputs](#pre-filled-id-inputs) below.                  |
+| Option                         | Type      | Default | Description                                                                                                                                         |
+| ------------------------------ | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hide_attribution`             | `boolean` | `false` | Hide Smile ID attribution/credits                                                                                                                   |
+| `allow_agent_mode`             | `boolean` | `false` | Allow agent mode for assisted capture                                                                                                               |
+| `use_strict_mode`              | `boolean` | `false` | Enables Enhanced SmartSelfie capture behavior. Set to `true` to enable strict-mode selfie capture.                                                  |
+| `allow_legacy_selfie_fallback` | `boolean` | `false` | Optional compatibility setting for legacy selfie fallback behavior.                                                                                 |
+| `id_info`                      | `object`  | —       | Pre-fill ID information fields. Keys are country codes mapping to ID types and field data. See [Pre-filled ID Inputs](#pre-filled-id-inputs) below. |
 
 ### Enhanced SmartSelfie
 
 Enhanced SmartSelfie capture is controlled through strict mode.
 
 - Enable Enhanced SmartSelfie by setting `use_strict_mode: true` at the top level of the SmileIdentity config.
-- If you also set `allow_legacy_selfie_fallback: true`, integration may fall back to legacy selfie capture when Mediapipe cannot initialize.
 
 ```javascript
 window.SmileIdentity({
   token: 'your-token',
   product: 'smartselfie',
   callback_url: 'https://your-callback.com',
-  allow_legacy_selfie_fallback: false,
   use_strict_mode: true,
   onSuccess: () => {},
   onError: () => {},
@@ -228,9 +226,6 @@ window.SmileIdentity({
   token: 'your-token',
   product: 'biometric_kyc',
   callback_url: 'https://your-callback.com',
-
-  // Optional: Allow legacy selfie fallback if Mediapipe fails
-  allow_legacy_selfie_fallback: true,
 
   // Set language (supports 'en-GB', 'fr-FR', 'ar-EG')
   translation: {

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -113,8 +113,28 @@ The embed supports several configuration options:
 | ------------------------------ | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `hide_attribution`             | `boolean` | `false` | Hide Smile ID attribution/credits                                                                                                                                    |
 | `allow_agent_mode`             | `boolean` | `false` | Allow agent mode for assisted capture                                                                                                                                |
+| `use_strict_mode`              | `boolean` | `false` | Enables Enhanced SmartSelfie capture behavior. Set to `true` to enable strict-mode selfie capture.                                                                   |
 | `allow_legacy_selfie_fallback` | `boolean` | `false` | Allow fallback to legacy selfie capture if Mediapipe fails to load. When `false` (default), an error message is shown instead of falling back to the legacy capture. |
 | `id_info`                      | `object`  | —       | Pre-fill ID information fields. Keys are country codes mapping to ID types and field data. See [Pre-filled ID Inputs](#pre-filled-id-inputs) below.                  |
+
+### Enhanced SmartSelfie
+
+Enhanced SmartSelfie capture is controlled through strict mode.
+
+- Enable Enhanced SmartSelfie by setting `use_strict_mode: true` at the top level of the SmileIdentity config.
+- If you also set `allow_legacy_selfie_fallback: true`, integration may fall back to legacy selfie capture when Mediapipe cannot initialize.
+
+```javascript
+window.SmileIdentity({
+  token: 'your-token',
+  product: 'smartselfie',
+  callback_url: 'https://your-callback.com',
+  allow_legacy_selfie_fallback: false,
+  use_strict_mode: true,
+  onSuccess: () => {},
+  onError: () => {},
+});
+```
 
 ## Pre-filled ID Inputs
 

--- a/packages/web-components/lib/components/selfie/README.md
+++ b/packages/web-components/lib/components/selfie/README.md
@@ -54,19 +54,8 @@ Usage:
 <selfie-capture-screens use-strict-mode="true"></selfie-capture-screens>
 ```
 
-#### allow-legacy-selfie-fallback
-
-Optional attribute that allows fallback to the legacy selfie flow when
-MediaPipe cannot initialize.
-
-Usage:
-
-```html
-<selfie-capture-screens
-  use-strict-mode="true"
-  allow-legacy-selfie-fallback="false"
-></selfie-capture-screens>
-```
+`allow-legacy-selfie-fallback` is also available as an optional compatibility
+attribute.
 
 ### Permissions
 

--- a/packages/web-components/lib/components/selfie/README.md
+++ b/packages/web-components/lib/components/selfie/README.md
@@ -44,6 +44,30 @@ Usage:
 <selfie-capture-screens show-navigation></selfie-capture-screens>
 ```
 
+#### use-strict-mode
+
+This attribute enables Enhanced SmartSelfie (strict-mode capture flow).
+
+Usage:
+
+```html
+<selfie-capture-screens use-strict-mode="true"></selfie-capture-screens>
+```
+
+#### allow-legacy-selfie-fallback
+
+Optional attribute that allows fallback to the legacy selfie flow when
+MediaPipe cannot initialize.
+
+Usage:
+
+```html
+<selfie-capture-screens
+  use-strict-mode="true"
+  allow-legacy-selfie-fallback="false"
+></selfie-capture-screens>
+```
+
 ### Permissions
 
 The `SelfieCaptureScreens` component requires camera permissions to function. It will automatically request these permissions when used. If the permissions are granted, it will remove the `data-camera-error` attribute from the capture screen and set the `data-camera-ready` attribute to true. If the permissions are denied, it will remove the `data-camera-ready` attribute and set the `data-camera-error` attribute with the error message.

--- a/packages/web-components/lib/components/smart-camera-web/src/README.md
+++ b/packages/web-components/lib/components/smart-camera-web/src/README.md
@@ -193,6 +193,23 @@ After installation and necessary imports:
 
    This approach can also be achieved using other Server to Server libraries.
 
+### Enhanced SmartSelfie (Strict Mode)
+
+For web-component integrations, Enhanced SmartSelfie is enabled with the
+`use-strict-mode` attribute on the component.
+
+```html
+<smart-camera-web
+  use-strict-mode="true"
+  allow-legacy-selfie-fallback="false"
+></smart-camera-web>
+```
+
+- Set `use-strict-mode="true"` to enable strict-mode selfie capture.
+- `allow-legacy-selfie-fallback="true"` is optional. If enabled, the
+  component can fall back to the legacy selfie flow when MediaPipe cannot
+  initialize.
+
 ## Compatibility
 
 `SmartCameraWeb` is compatible with most JavaScript frameworks and libraries. For integration with [ReactJS](https://reactjs.org), refer to this [tutorial](https://www.robinwieruch.de/react-web-components) due to React-WebComponents compatibility issues.

--- a/packages/web-components/lib/components/smart-camera-web/src/README.md
+++ b/packages/web-components/lib/components/smart-camera-web/src/README.md
@@ -193,22 +193,16 @@ After installation and necessary imports:
 
    This approach can also be achieved using other Server to Server libraries.
 
-### Enhanced SmartSelfie (Strict Mode)
+### Enhanced SmartSelfie
 
 For web-component integrations, Enhanced SmartSelfie is enabled with the
 `use-strict-mode` attribute on the component.
 
 ```html
-<smart-camera-web
-  use-strict-mode="true"
-  allow-legacy-selfie-fallback="false"
-></smart-camera-web>
+<smart-camera-web use-strict-mode="true"></smart-camera-web>
 ```
 
 - Set `use-strict-mode="true"` to enable strict-mode selfie capture.
-- `allow-legacy-selfie-fallback="true"` is optional. If enabled, the
-  component can fall back to the legacy selfie flow when MediaPipe cannot
-  initialize.
 
 ## Compatibility
 


### PR DESCRIPTION
### **User description**
## Summary
- document `use_strict_mode` as the embed-level config key for Enhanced SmartSelfie
- clarify that web components use the `use-strict-mode` attribute
- add strict-mode usage examples in SmartCameraWeb and SelfieCaptureScreens docs
- keep legacy fallback guidance alongside strict-mode examples

## Files Updated
- packages/embed/README.md
- packages/web-components/lib/components/smart-camera-web/src/README.md
- packages/web-components/lib/components/selfie/README.md

## Validation
- formatted markdown with Prettier


___

### **PR Type**
Documentation


___

### **Description**
- Document `use_strict_mode` config for Enhanced SmartSelfie in embed

- Add `use-strict-mode` attribute docs for selfie-capture-screens component

- Add Enhanced SmartSelfie section to smart-camera-web README

- Include legacy fallback guidance alongside strict-mode examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["use_strict_mode config"] -- "embed" --> B["packages/embed README"]
  A -- "web component attr" --> C["smart-camera-web README"]
  A -- "web component attr" --> D["selfie-capture-screens README"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add strict mode config and Enhanced SmartSelfie section</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/README.md

<ul><li>Added <code>use_strict_mode</code> to the configuration options table<br> <li> Added new "Enhanced SmartSelfie" section with explanation and <br>JavaScript usage example<br> <li> Shows how <code>use_strict_mode</code> and <code>allow_legacy_selfie_fallback</code> work <br>together</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/674/files#diff-bf5a3b51ba2dff8d24a3e98df90f2f0a6a9e21bdb13ae7cea38fd1530137fcac">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document strict mode and fallback attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/selfie/README.md

<ul><li>Documented <code>use-strict-mode</code> attribute with HTML usage example<br> <li> Documented <code>allow-legacy-selfie-fallback</code> attribute with combined usage <br>example</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/674/files#diff-3f0f54399197607e6ca0d0b4fbfa876976932aa1813dac523f64ee074ff32fac">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Enhanced SmartSelfie strict mode section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-components/lib/components/smart-camera-web/src/README.md

<ul><li>Added "Enhanced SmartSelfie (Strict Mode)" section<br> <li> Provided HTML example showing <code>use-strict-mode</code> and <br><code>allow-legacy-selfie-fallback</code> attributes<br> <li> Explained behavior of each attribute</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/674/files#diff-c2762c5f3e4db559601e70e7819cdb299d98f650ff2ee112be1a18c788e8c4a2">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>