### PR TITLE
test(embed): stabilize flaky document-capture camera e2e

### DIFF
--- a/packages/embed/cypress/tests/document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/document-verification.cy.cjs
@@ -68,7 +68,8 @@ describe('document verification', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()
@@ -223,7 +224,8 @@ describe('legacy support - preselected country / id_types', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()

--- a/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
@@ -67,7 +67,8 @@ describe('enhanced document verification', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()

--- a/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification.cy.cjs
@@ -67,7 +67,8 @@ describe('enhanced document verification', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()

--- a/packages/embed/cypress/tests/id-selection.cy.cjs
+++ b/packages/embed/cypress/tests/id-selection.cy.cjs
@@ -176,7 +176,8 @@ describe('No ID Selection', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()
@@ -439,7 +440,8 @@ describe('Preselected Country', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()
@@ -696,7 +698,8 @@ describe('Preselected Country and ID Type', () => {
       .shadow()
       .find('document-capture#document-capture-front')
       .shadow()
-      .find('#capture-id-image')
+      .find('#capture-id-image', { timeout: 15000 })
+      .should('be.visible')
       .click();
 
     cy.getIFrameBody()


### PR DESCRIPTION
### **User description**
## Problem

`enhanced document verification > should capture selfie and id image` (and the same flow in `document-verification`, `enhanced-document-verification-dev`, `id-selection`) intermittently fails CI with:

> `cy.click()` failed because this element is not visible: `<button id="capture-id-image">` … its parent `<div.actions>` has CSS property: `display: none`

This surfaced as the only red check on PR #675, failing ~50% of runs (failed → passed on re-run → failed again), **even though `cypress.config.js` has `retries.runMode: 2`** — all 3 attempts lost the race.

## Root cause

In `DocumentCapture.js` the `.actions` div (which contains `#capture-id-image`) starts `hidden` and is only revealed inside `video.onloadedmetadata`. Under the headless fake camera (`--use-fake-device-for-media-stream`), `loadedmetadata` fires slowly/inconsistently, so the default **4s** click-actionability timeout expires before `.actions` un-hides → flake. The component's `loadedmetadata` gating is correct for real cameras; this is purely a CI/headless timing artifact.

## Fix

Test-only: wait up to **15s** for `#capture-id-image` to be visible before clicking, in all 4 specs that drive the document-capture front screen (7 sites):

```js
.find('#capture-id-image', { timeout: 15000 })
.should('be.visible')
.click();
```

No production code changes.

## Verification

- Transform applied to all 7 `#capture-id-image` clicks; prettier-clean.
- Local headless camera e2e is inherently flaky to reproduce; the fix targets the confirmed root cause (actions revealed late). CI on this PR will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Tests


___

### **Description**
- Fix flaky document-capture e2e tests in CI

- Add 15s timeout for camera-gated capture button visibility

- Apply fix across 7 click sites in 4 spec files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Camera["Fake headless camera"] -- "slow loadedmetadata" --> Actions["`.actions` div hidden"]
  Actions -- "default 4s timeout" --> Flake["Test flake: element not visible"]
  Actions -- "15s timeout + visibility check" --> Stable["Stable test execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-verification.cy.cjs</strong><dd><code>Add timeout and visibility check for capture button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/document-verification.cy.cjs

<ul><li>Added 15s timeout to <code>#capture-id-image</code> find calls (2 sites)<br> <li> Added <code>.should('be.visible')</code> assertion before <code>.click()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/680/files#diff-b457f1f37d8d1a933f526fe0849c1a88d244e499f6d7351f0a31c590036daa62">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification-dev.cy.cjs</strong><dd><code>Add timeout and visibility check for capture button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs

<ul><li>Added 15s timeout to <code>#capture-id-image</code> find call<br> <li> Added <code>.should('be.visible')</code> assertion before <code>.click()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/680/files#diff-8a3ef0ddc7ad8a9ba4b9238a374a7a38d1386854fc13e33b0fd182cc1b3f64b8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification.cy.cjs</strong><dd><code>Add timeout and visibility check for capture button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/enhanced-document-verification.cy.cjs

<ul><li>Added 15s timeout to <code>#capture-id-image</code> find call<br> <li> Added <code>.should('be.visible')</code> assertion before <code>.click()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/680/files#diff-75ff006a2d870eecdc90970589e2005869af5bec818f97e699b2c20343d7b57c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>id-selection.cy.cjs</strong><dd><code>Add timeout and visibility check for capture button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/id-selection.cy.cjs

<ul><li>Added 15s timeout to <code>#capture-id-image</code> find calls (3 sites)<br> <li> Added <code>.should('be.visible')</code> assertion before each <code>.click()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/680/files#diff-d60d36c2dc61c051dc6e10cc33bb125c03b363bd5781ed30393fe493b8846209">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>