### PR TITLE
test(embed): stabilize enhanced document verification dev camera flow

### DIFF
--- a/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
+++ b/packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs
@@ -1,5 +1,54 @@
 describe('enhanced document verification', () => {
   beforeEach(() => {
+    const stubHostedIframeCamera = () => {
+      cy.get('iframe[data-cy="smile-identity-hosted-web-integration"]')
+        .its('0.contentWindow')
+        .should('exist')
+        .then((iframeWin) => {
+          const fakeDeviceId = 'fake-device';
+          const canvas = iframeWin.document.createElement('canvas');
+          canvas.width = 640;
+          canvas.height = 480;
+          const ctx = canvas.getContext('2d');
+          if (ctx) {
+            ctx.fillStyle = '#000';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+          }
+
+          const fakeStream = canvas.captureStream(30);
+
+          // The app resolves camera name by matching track.getSettings().deviceId
+          // to enumerateDevices() output. Canvas streams do not provide a useful
+          // deviceId by default, so we patch it for deterministic metadata.
+          const [videoTrack] = fakeStream.getVideoTracks();
+          if (videoTrack && typeof videoTrack.getSettings === 'function') {
+            const originalGetSettings = videoTrack.getSettings.bind(videoTrack);
+            videoTrack.getSettings = () => ({
+              ...originalGetSettings(),
+              deviceId: fakeDeviceId,
+            });
+          }
+
+          const mediaDevices = iframeWin.navigator.mediaDevices || {};
+
+          Object.defineProperty(iframeWin.navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+              ...mediaDevices,
+              enumerateDevices: () =>
+                Promise.resolve([
+                  {
+                    deviceId: fakeDeviceId,
+                    kind: 'videoinput',
+                    label: 'Fake Camera',
+                  },
+                ]),
+              getUserMedia: () => Promise.resolve(fakeStream),
+            },
+          });
+        });
+    };
+
     cy.intercept(
       {
         method: 'POST',
@@ -24,6 +73,8 @@ describe('enhanced document verification', () => {
     cy.loadIDOptions('https://example.smileidentity.com/v1');
 
     cy.visit('/enhanced_document_verification_dev');
+
+    stubHostedIframeCamera();
 
     cy.selectVOTERIDType();
 
@@ -66,8 +117,22 @@ describe('enhanced document verification', () => {
       .find('smart-camera-web')
       .shadow()
       .find('document-capture#document-capture-front')
+      .should('have.attr', 'data-camera-ready', 'true');
+
+    cy.getIFrameBody()
+      .find('smart-camera-web')
       .shadow()
-      .find('#capture-id-image', { timeout: 15000 })
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .find('#loader')
+      .should('have.prop', 'hidden', true);
+
+    cy.getIFrameBody()
+      .find('smart-camera-web')
+      .shadow()
+      .find('document-capture#document-capture-front')
+      .shadow()
+      .find('#capture-id-image')
       .should('be.visible')
       .click();
 


### PR DESCRIPTION
### **User description**
## Summary
- stub hosted iframe camera in enhanced document verification dev Cypress test
- make fake camera metadata deterministic by aligning track deviceId with enumerateDevices
- keep readiness assertions while removing explicit timeout overrides

## Context
- addresses embed CI flakiness around document capture readiness in the dev flow


___

### **PR Type**
Tests


___

### **Description**
- Stub hosted iframe camera for deterministic test behavior

- Align fake track deviceId with enumerateDevices output

- Add camera readiness assertions before capture interaction

- Remove explicit timeout override on capture button selector


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stubHostedIframeCamera()"] -- "creates" --> B["Fake canvas stream"]
  B -- "patches" --> C["videoTrack.getSettings().deviceId"]
  A -- "overrides" --> D["navigator.mediaDevices"]
  D -- "provides" --> E["getUserMedia / enumerateDevices"]
  E -- "enables" --> F["Deterministic camera readiness"]
  F -- "asserts" --> G["data-camera-ready & loader hidden"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enhanced-document-verification-dev.cy.cjs</strong><dd><code>Stub iframe camera and add readiness assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/embed/cypress/tests/enhanced-document-verification-dev.cy.cjs

<ul><li>Added <code>stubHostedIframeCamera</code> helper that creates a fake canvas-based <br>video stream inside the hosted iframe<br> <li> Patched <code>videoTrack.getSettings()</code> to return a deterministic <code>deviceId</code> <br>matching the stubbed <code>enumerateDevices</code> output<br> <li> Overrode <code>navigator.mediaDevices</code> on the iframe window with fake <br><code>getUserMedia</code> and <code>enumerateDevices</code><br> <li> Added assertions for <code>data-camera-ready</code> attribute and <code>#loader</code> hidden <br>state before clicking capture<br> <li> Removed <code>{ timeout: 15000 }</code> from <code>#capture-id-image</code> selector</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/685/files#diff-8a3ef0ddc7ad8a9ba4b9238a374a7a38d1386854fc13e33b0fd182cc1b3f64b8">+66/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>