### PR TITLE
fix(previews): use managed CloudFront cache policy for preview stages

### DIFF
--- a/previews/sst.config.ts
+++ b/previews/sst.config.ts
@@ -37,6 +37,10 @@ export default $config({
 
     const site = new sst.aws.React('PreviewApp', {
       link: [api, EmbedUrl, PARTNER_ID],
+      // AWS-managed CachingDisabled policy. Previews don't need edge caching of
+      // server responses, and per-stage custom policies exhaust the account
+      // quota (~20) when `sst remove` fails to detach them from a distribution.
+      cachePolicy: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
       transform: {
         cdn: {
           transform: {


### PR DESCRIPTION
### **User description**
## Summary
- Point the `PreviewApp` SST site at the AWS-managed `CachingDisabled` CloudFront cache policy instead of letting SST auto-create a custom per-stage policy.
- Each PR currently spins up two stages (sandbox + prod), each creating its own custom cache policy. If `sst remove` fails to fully detach a policy from its distribution during preview teardown, the policy is orphaned. CloudFront enforces a ~20 custom-cache-policy quota per account, so accumulated orphans from deleted preview apps eventually block new preview deploys.
- Using the managed policy means preview stages no longer create any custom cache policies at all, eliminating the orphan/quota issue at the source.

## Test plan
- [ ] Open this PR and confirm `deploy-preview` succeeds and the preview URL loads/renders normally
- [ ] Confirm no new custom CloudFront cache policy is created for this PR's stages (`aws cloudfront list-cache-policies --type custom`)
- [ ] Confirm the WAF ACL transform on the distribution still applies
- [ ] Close the PR and confirm `destroy-preview` tears down cleanly with no orphaned policy left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Use AWS-managed CachingDisabled CloudFront cache policy for previews

- Prevents custom cache policy quota exhaustion from orphaned policies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Preview Deploy"] -- "previously created" --> B["Custom Cache Policy"]
  B -- "orphaned on teardown" --> C["Account Quota Exhausted"]
  A -- "now uses" --> D["AWS Managed CachingDisabled Policy"]
  D -- "no quota impact" --> E["Reliable Deploys"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sst.config.ts</strong><dd><code>Set managed CachingDisabled policy on PreviewApp site</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

previews/sst.config.ts

<ul><li>Added <code>cachePolicy</code> property pointing to the AWS-managed <code>CachingDisabled</code> <br>policy ID (<code>4135ea2d-6df8-44a3-9df3-4b5a84be39ad</code>)<br> <li> Added comment explaining the rationale (no edge caching needed, avoids <br>quota exhaustion)</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/692/files#diff-daaf5ffe465be5314b6a67701b39dafdacfc7fd167a3442734b27e2cd596d68d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>