### PR TITLE
Import Semgrep results into DefectDojo

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## What

Adds a non-blocking "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, run right after the existing "Upload SARIF to GitHub Security" step. It reimports the Semgrep SARIF output into [DefectDojo](https://defectdojo.smile.id) via `POST /api/v2/reimport-scan/`, so findings get an aggregated view across repos instead of only living in PR checks / GitHub Code Scanning.

- Skips gracefully (no failure) if the SARIF file is missing or empty
- `continue-on-error: true` + `if: always()` so it never blocks the build
- Auth token is read from `DEFECTDOJO_API_TOKEN` via an `env:` block, not inlined in the curl args
- Uses the org-wide `DEFECTDOJO_URL` / `DEFECTDOJO_API_TOKEN` secrets already scoped to this repo (no new secrets added)

**SARIF filename used in this repo:** `semgrep.sarif` — produced by the existing `semgrep scan --config p/security-audit --sarif -o semgrep.sarif` step. Same filename as `smileidentity/lambda`, so no path adjustment was needed.

This mirrors `smileidentity/lambda#4662` (same template, currently **open/unmerged** but already verified working via its own `pull_request`-triggered CI run).

## Test plan

- [ ] Confirm the `semgrep` job's CI run on this PR shows the new "Import results into DefectDojo" step running (should succeed or no-op harmlessly even if DefectDojo is briefly unavailable, since it's `continue-on-error`)
- [ ] Spot-check in DefectDojo that a `web-client` product/engagement gets created/updated with this scan's findings
- [ ] Human review + merge (not auto-merged per repo convention)


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo SARIF import step to Semgrep workflow

- Non-blocking step with graceful skip on missing file

- Uses org-wide secrets for DefectDojo authentication

- Enables aggregated vulnerability findings across repos


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] -- "produces" --> B["semgrep.sarif"]
  B -- "upload" --> C["GitHub Security"]
  B -- "reimport" --> D["DefectDojo API"]
  D -- "aggregates" --> E["Centralized Findings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add non-blocking DefectDojo reimport step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Step uses <code>curl</code> to POST the SARIF file to DefectDojo's reimport-scan <br>API endpoint<br> <li> Includes graceful skip when <code>semgrep.sarif</code> is missing or empty<br> <li> Configured with <code>continue-on-error: true</code> and <code>if: always()</code> to avoid <br>blocking the pipeline<br> <li> Passes repository name, commit hash, and branch as metadata to <br>DefectDojo</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/693/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>