### PR TITLE
fix(previews): cap preview stage name under Pulumi's 100-char limit

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -119,6 +119,8 @@ jobs:
           echo "DEST_DIR_EMBED=inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_ENV"
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
+          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> "$GITHUB_OUTPUT"
       - name: install dependencies
         run: npm install

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -120,7 +120,19 @@ jobs:
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
-          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
+          if [ "${#SANITIZED_BRANCH_NAME}" -gt 90 ]; then
+            BRANCH_HASH=$(printf '%s' "$BRANCH_NAME" | git hash-object --stdin | cut -c1-8)
+            SANITIZED_BRANCH_PREFIX=$(printf '%s' "$SANITIZED_BRANCH_NAME" | cut -c1-81 | sed 's/-*$//')
+            if [ -n "$SANITIZED_BRANCH_PREFIX" ]; then
+              SANITIZED_BRANCH_NAME="$SANITIZED_BRANCH_PREFIX-$BRANCH_HASH"
+            else
+              SANITIZED_BRANCH_NAME="$BRANCH_HASH"
+            fi
+          fi
+          if [ -z "$SANITIZED_BRANCH_NAME" ]; then
+            echo "::error::Sanitized branch name is empty"
+            exit 1
+          fi
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> "$GITHUB_OUTPUT"
       - name: install dependencies
         run: npm install
@@ -194,7 +206,19 @@ jobs:
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
-          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
+          if [ "${#SANITIZED_BRANCH_NAME}" -gt 90 ]; then
+            BRANCH_HASH=$(printf '%s' "$BRANCH_NAME" | git hash-object --stdin | cut -c1-8)
+            SANITIZED_BRANCH_PREFIX=$(printf '%s' "$SANITIZED_BRANCH_NAME" | cut -c1-81 | sed 's/-*$//')
+            if [ -n "$SANITIZED_BRANCH_PREFIX" ]; then
+              SANITIZED_BRANCH_NAME="$SANITIZED_BRANCH_PREFIX-$BRANCH_HASH"
+            else
+              SANITIZED_BRANCH_NAME="$BRANCH_HASH"
+            fi
+          fi
+          if [ -z "$SANITIZED_BRANCH_NAME" ]; then
+            echo "::error::Sanitized branch name is empty"
+            exit 1
+          fi
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> "$GITHUB_ENV"
       - name: retrieve sst app url
         continue-on-error: true

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -193,6 +193,8 @@ jobs:
         run: |
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
+          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> "$GITHUB_ENV"
       - name: retrieve sst app url
         continue-on-error: true

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -33,7 +33,19 @@ jobs:
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
-          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
+          if [ "${#SANITIZED_BRANCH_NAME}" -gt 90 ]; then
+            BRANCH_HASH=$(printf '%s' "$BRANCH_NAME" | git hash-object --stdin | cut -c1-8)
+            SANITIZED_BRANCH_PREFIX=$(printf '%s' "$SANITIZED_BRANCH_NAME" | cut -c1-81 | sed 's/-*$//')
+            if [ -n "$SANITIZED_BRANCH_PREFIX" ]; then
+              SANITIZED_BRANCH_NAME="$SANITIZED_BRANCH_PREFIX-$BRANCH_HASH"
+            else
+              SANITIZED_BRANCH_NAME="$BRANCH_HASH"
+            fi
+          fi
+          if [ -z "$SANITIZED_BRANCH_NAME" ]; then
+            echo "::error::Sanitized branch name is empty"
+            exit 1
+          fi
           echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
       - name: install dependencies
         run: npm install

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           BRANCH_NAME="$BRANCH_REF"
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
+          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
           echo "SS_STAGE=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
       - name: install dependencies
         run: npm install

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -34,13 +34,13 @@ jobs:
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
           SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
-          echo "SS_STAGE=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "SST_STAGE=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
       - name: install dependencies
         run: npm install
       - name: remove sst app (sandbox)
         run: |
-          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SS_STAGE }}
+          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
       - name: remove sst app (prod)
-        if: ${{ always() && steps.get_branch_name.outcome == 'success' && steps.get_branch_name.outputs.SS_STAGE != '' }}
+        if: ${{ always() && steps.get_branch_name.outcome == 'success' && steps.get_branch_name.outputs.SST_STAGE != '' }}
         run: |
-          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SS_STAGE }}-prod
+          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}-prod

--- a/.github/workflows/share-preview-url.yml
+++ b/.github/workflows/share-preview-url.yml
@@ -51,7 +51,19 @@ jobs:
           fi
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
-          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
+          if [ "${#SANITIZED_BRANCH_NAME}" -gt 90 ]; then
+            BRANCH_HASH=$(printf '%s' "$BRANCH_NAME" | git hash-object --stdin | cut -c1-8)
+            SANITIZED_BRANCH_PREFIX=$(printf '%s' "$SANITIZED_BRANCH_NAME" | cut -c1-81 | sed 's/-*$//')
+            if [ -n "$SANITIZED_BRANCH_PREFIX" ]; then
+              SANITIZED_BRANCH_NAME="$SANITIZED_BRANCH_PREFIX-$BRANCH_HASH"
+            else
+              SANITIZED_BRANCH_NAME="$BRANCH_HASH"
+            fi
+          fi
+          if [ -z "$SANITIZED_BRANCH_NAME" ]; then
+            echo "::error::Sanitized branch name is empty"
+            exit 1
+          fi
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> $GITHUB_ENV
       - name: retrieve sst app url (sandbox)

--- a/.github/workflows/share-preview-url.yml
+++ b/.github/workflows/share-preview-url.yml
@@ -50,6 +50,8 @@ jobs:
             BRANCH_NAME="${{ github.ref_name }}"
           fi
           SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
+          SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> $GITHUB_ENV
       - name: retrieve sst app url (sandbox)


### PR DESCRIPTION
### **User description**
## Problem

Deploying the **prod** preview stage fails for long branch names (e.g. dependabot bumps) immediately after pulling state, before any AWS resource is touched. SST's TTY UI hides the real error, which lives in `previews/.sst/log/pulumi.err.log`:

```
error: a stack name cannot exceed 100 characters
```

The SST stage name is derived from the sanitized branch name. For the signature-pad dependabot branch the sanitized name is **exactly 100 chars** — so the sandbox stage *just barely* deploys, but the prod stage appends `-prod` → **105 chars** → over Pulumi's hard cap → abort.

## Fix

Truncate the sanitized branch name to **90 chars** (10 chars of headroom past the 5-char `-prod` suffix) and strip trailing dashes, applied **identically** in all three workflows that independently derive the stage name so deploy / destroy / share-URL all target the same stage:

```bash
SANITIZED_BRANCH_NAME=$(echo "$SANITIZED_BRANCH_NAME" | cut -c1-90 | sed 's/-*$//')
```

No-op for branches whose sanitized name is ≤ 90 chars.

- `deploy-preview.yml`
- `destroy-preview.yml`
- `share-preview-url.yml`

## Verification

- Worst-case 90-char stage → sandbox 90 / prod 95, both ≤ 100.
- Signature-pad branch → sandbox 89 / prod 94.
- Short branches (`main`, `fix-foo`) unchanged.
- The three inserted snippets are byte-identical.

## Caveat

Branches that already deployed a sandbox stage under the *full* (untruncated) name will orphan that stage — the new logic (and `destroy-preview`) now targets the truncated name. If needed, `sst remove --stage <full-name>` the old sandbox stage once. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Truncate preview stage names to 90 chars for Pulumi's 100-char limit

- Applied identically across deploy, destroy, and share-preview-url workflows

- Strips trailing dashes after truncation

- Fixes prod stage deployment failures on long branch names


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long branch name"] -- "sanitize" --> B["Sanitized name"]
  B -- "cut -c1-90 + strip dashes" --> C["Truncated name ≤90 chars"]
  C -- "+'-prod'" --> D["Prod stage ≤95 chars < 100"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-preview.yml</strong><dd><code>Cap stage name length in deploy workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-preview.yml

<ul><li>Added truncation of <code>SANITIZED_BRANCH_NAME</code> to 90 characters with <br>trailing dash removal after the initial sanitization step</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/694/files#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>destroy-preview.yml</strong><dd><code>Cap stage name length in destroy workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/destroy-preview.yml

<ul><li>Added identical truncation of <code>SANITIZED_BRANCH_NAME</code> to 90 characters <br>with trailing dash removal to keep destroy targeting the same stage as <br>deploy</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/694/files#diff-5bed374909e109c4053da7168d3e96b887f9789fc4bff6b4886e88f1f7872ac8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>share-preview-url.yml</strong><dd><code>Cap stage name length in share-url workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/share-preview-url.yml

<ul><li>Added identical truncation of <code>SANITIZED_BRANCH_NAME</code> to 90 characters <br>with trailing dash removal to keep URL sharing consistent with <br>deploy/destroy</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/694/files#diff-c0d6ec4a944f2a53e5f85b349e7e77c282f963ba19ab5e7032ea7ae07f29971b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>