### PR TITLE
ci(preview): stop preview environment resource leaks

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,11 @@ on:
     types:
       - opened
       - synchronize
+# Serialises deploy and destroy in both directions for a given branch, so a
+# manual re-run never races a PR-triggered run against the same SST stage.
+concurrency:
+  group: preview-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: false
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     types:
       - closed
+# Serialises deploy and destroy in both directions for a given branch, so a
+# manual re-run never races a PR-triggered run against the same SST stage.
+concurrency:
+  group: preview-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: false
 permissions:
   id-token: write
   contents: read
@@ -50,9 +55,26 @@ jobs:
       - name: install dependencies
         run: npm install
       - name: remove sst app (sandbox)
+        env:
+          STAGE: ${{ steps.get_branch_name.outputs.SST_STAGE }}
         run: |
-          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}
+          npm run sst remove -- --stage "$STAGE" --print-logs || {
+            echo "sst remove failed, retrying in 60s..."
+            sleep 60
+            npm run sst remove -- --stage "$STAGE" --print-logs
+          }
       - name: remove sst app (prod)
         if: ${{ always() && steps.get_branch_name.outcome == 'success' && steps.get_branch_name.outputs.SST_STAGE != '' }}
+        env:
+          STAGE: ${{ steps.get_branch_name.outputs.SST_STAGE }}-prod
         run: |
-          npm run sst remove -- --stage ${{ steps.get_branch_name.outputs.SST_STAGE }}-prod
+          npm run sst remove -- --stage "$STAGE" --print-logs || {
+            echo "sst remove failed, retrying in 60s..."
+            sleep 60
+            npm run sst remove -- --stage "$STAGE" --print-logs
+          }
+      - name: delete s3 preview prefixes
+        if: always()
+        run: |
+          aws s3 rm --recursive "s3://${{ secrets.AWS_S3_BUCKET }}/js/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}/"
+          aws s3 rm --recursive "s3://${{ secrets.AWS_S3_BUCKET }}/inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}/"

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -76,5 +76,8 @@ jobs:
       - name: delete s3 preview prefixes
         if: always()
         run: |
+          # Deliberately the RAW branch name, not the sanitised SST stage:
+          # deploy-preview.yml syncs to js/preview-<raw branch> and
+          # inline/preview-<raw branch>, so the delete must match byte for byte.
           aws s3 rm --recursive "s3://${{ secrets.AWS_S3_BUCKET }}/js/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}/"
           aws s3 rm --recursive "s3://${{ secrets.AWS_S3_BUCKET }}/inline/preview-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}/"

--- a/.github/workflows/preview-sweeper.yml
+++ b/.github/workflows/preview-sweeper.yml
@@ -1,0 +1,144 @@
+name: preview-sweeper
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+jobs:
+  sweep:
+    defaults:
+      run:
+        working-directory: ./previews
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: install sst
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ion.sst.dev/install | VERSION=3.4.5 bash
+      - name: install dependencies
+        run: |
+          set -euo pipefail
+          npm install
+      - name: find and remove stale preview stages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Capture the open-PR list into a variable first so a `gh` failure trips
+          # `set -e` here, rather than being swallowed by a `for B in $(...)` loop
+          # (which would silently iterate zero times and treat every deployed
+          # stage as stale).
+          OPEN_BRANCHES=$(gh pr list --state open --limit 1000 --json headRefName --jq '.[].headRefName')
+          BRANCH_COUNT=$(printf '%s\n' "$OPEN_BRANCHES" | wc -l | tr -d ' ')
+
+          if [ -z "$OPEN_BRANCHES" ]; then
+            echo "::error::gh pr list returned no open branches. Refusing to sweep, as an empty keep-list would mark every deployed stage as stale."
+            exit 1
+          fi
+          if [ "$BRANCH_COUNT" -ge 1000 ]; then
+            echo "::error::gh pr list returned 1000 branches, which may mean the result was truncated by --limit. Refusing to sweep until this is investigated."
+            exit 1
+          fi
+
+          # Build the keep-set: for every open PR's sanitized stage name S, keep
+          # both S (sandbox) and S-prod (production variant). Matching against
+          # this exact set (rather than stripping a trailing "-prod" from every
+          # tagged stage and comparing) means a branch whose own name ends in
+          # "-prod" can't be confused with another branch's production variant.
+          KEEP_FILE="$RUNNER_TEMP/preview-sweeper-keep-stages.txt"
+          : > "$KEEP_FILE"
+          while IFS= read -r BRANCH_NAME; do
+            [ -z "$BRANCH_NAME" ] && continue
+            SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+            # Pulumi caps stack names at 100 chars; reserve headroom for the "-prod" variant.
+            if [ "${#SANITIZED_BRANCH_NAME}" -gt 90 ]; then
+              BRANCH_HASH=$(printf '%s' "$BRANCH_NAME" | git hash-object --stdin | cut -c1-8)
+              SANITIZED_BRANCH_PREFIX=$(printf '%s' "$SANITIZED_BRANCH_NAME" | cut -c1-81 | sed 's/-*$//')
+              if [ -n "$SANITIZED_BRANCH_PREFIX" ]; then
+                SANITIZED_BRANCH_NAME="$SANITIZED_BRANCH_PREFIX-$BRANCH_HASH"
+              else
+                SANITIZED_BRANCH_NAME="$BRANCH_HASH"
+              fi
+            fi
+            echo "$SANITIZED_BRANCH_NAME" >> "$KEEP_FILE"
+            echo "${SANITIZED_BRANCH_NAME}-prod" >> "$KEEP_FILE"
+          done <<< "$OPEN_BRANCHES"
+
+          # Stages currently tagged sst:app=previews AND repo=web-client on a live
+          # CloudFront distribution. The sibling web-sdk repo deploys an SST app
+          # with the SAME name ("previews") into the same AWS account, so the
+          # repo tag is required here - without it, this would also match (and
+          # then remove) web-sdk's live preview stages. Stages tagged sst:app
+          # before the repo tag was added need one-off manual cleanup; they are
+          # deliberately excluded from this automated sweep.
+          TAGGED_STAGES=$(aws resourcegroupstaggingapi get-resources \
+            --tag-filters Key=sst:app,Values=previews Key=repo,Values=web-client \
+            --resource-type-filters cloudfront:distribution \
+            --region us-east-1 \
+            --query "ResourceTagMappingList[].Tags[?Key=='sst:stage'].Value" \
+            --output text | tr '\t' '\n' | sort -u)
+
+          echo "Tagged preview stages (this repo):"
+          echo "$TAGGED_STAGES"
+          echo "Keep set:"
+          cat "$KEEP_FILE"
+
+          STALE_FILE="$RUNNER_TEMP/preview-sweeper-stale-stages.txt"
+          : > "$STALE_FILE"
+
+          while IFS= read -r STAGE; do
+            [ -z "$STAGE" ] && continue
+
+            # This repo's previews app has removal: 'retain' for production, so
+            # a "production" (and "production-prod") stage is expected to exist
+            # permanently and must never be swept. Same for staging/main, in
+            # case those are ever used as a stage name directly.
+            BASE_STAGE="${STAGE%-prod}"
+            case "$BASE_STAGE" in
+              production | staging | main)
+                echo "Skipping protected stage $STAGE (base $BASE_STAGE)"
+                continue
+                ;;
+            esac
+
+            if grep -Fxq "$STAGE" "$KEEP_FILE"; then
+              echo "Keeping $STAGE (open PR)"
+            else
+              echo "No open PR keeps $STAGE, marking for removal"
+              echo "$STAGE" >> "$STALE_FILE"
+            fi
+          done <<< "$TAGGED_STAGES"
+
+          FAILED=0
+          if [ -s "$STALE_FILE" ]; then
+            while IFS= read -r STAGE; do
+              [ -z "$STAGE" ] && continue
+              # AWS tag values are untrusted input; validate before use even
+              # though this is a file read, not a template interpolation.
+              if ! printf '%s' "$STAGE" | grep -qE '^[A-Za-z0-9-]+$'; then
+                echo "::warning::Skipping stale stage with unexpected characters: $STAGE"
+                FAILED=1
+                continue
+              fi
+              echo "Removing stage $STAGE"
+              npm run sst remove -- --stage "$STAGE" --print-logs </dev/null || {
+                echo "::error::Could not remove stage $STAGE (may already be gone)"
+                FAILED=1
+              }
+            done < "$STALE_FILE"
+          else
+            echo "No stale preview stages found"
+          fi
+
+          exit $FAILED

--- a/.github/workflows/preview-sweeper.yml
+++ b/.github/workflows/preview-sweeper.yml
@@ -35,11 +35,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Capture the open-PR list into a variable first so a `gh` failure trips
-          # `set -e` here, rather than being swallowed by a `for B in $(...)` loop
-          # (which would silently iterate zero times and treat every deployed
-          # stage as stale).
-          OPEN_BRANCHES=$(gh pr list --state open --limit 1000 --json headRefName --jq '.[].headRefName')
+          # Capture the open-PR list with an explicit failure check, rather than
+          # inside a `for B in $(...)` loop (which would silently iterate zero
+          # times and treat every deployed stage as stale).
+          if ! OPEN_BRANCHES=$(gh pr list --state open --limit 1000 --json headRefName --jq '.[].headRefName'); then
+            echo "::error::gh pr list failed. Refusing to sweep, as an empty keep-list would mark every deployed stage as stale."
+            exit 1
+          fi
           BRANCH_COUNT=$(printf '%s\n' "$OPEN_BRANCHES" | wc -l | tr -d ' ')
 
           if [ -z "$OPEN_BRANCHES" ]; then

--- a/previews/sst.config.ts
+++ b/previews/sst.config.ts
@@ -7,6 +7,13 @@ export default $config({
       name: 'previews',
       removal: input?.stage === 'production' ? 'retain' : 'remove',
       home: 'aws',
+      providers: {
+        aws: {
+          defaultTags: {
+            tags: { repo: 'web-client' },
+          },
+        },
+      },
     };
   },
   async run() {


### PR DESCRIPTION
### **User description**
![gif](https://media2.giphy.com/media/v1.Y2lkPWNjNzE0YmE5Y2ZkYXNyNDJjcGViaXBybzkycDdrMnBzZGxlN3l4dzN2b3RyNDg3cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ra6UhlGcVrUouMGdW4/giphy.gif)

## Summary

Same leak, same fix as the web-sdk PR: preview deploy/destroy raced each other, `sst remove` failed silently, and the `js/preview-*` / `inline/preview-*` CDN prefixes were never cleaned up. Serialises the workflows, makes removals loud and retried, deletes the prefixes on PR close, and adds a weekly sweeper.

## Affected packages

- [x] Tooling / CI / docs

**Changes**

- Shared concurrency group `preview-<branch>` with `cancel-in-progress: false` on deploy-preview and destroy-preview.
- `sst remove` calls bind the stage via `env:` (no `${{ }}` splicing into run blocks), print logs, and retry once after 60 seconds.
- PR close deletes the two CDN preview prefixes for the branch.
- New `preview-sweeper.yml` (weekly): selects distributions tagged `sst:app=previews` and `repo=web-client`, keeps stages for open PRs by exact stage-set matching (stage and stage`-prod`), validates stage names against `^[A-Za-z0-9-]+$` before use (tag values are untrusted input), skips `production`/`staging`/`main`, refuses to sweep on an empty or truncated PR list, and exits non-zero if any removal fails.
- `previews/sst.config.ts` tags preview resources `repo: web-client` — web-sdk shares the SST app name, so without the tag a sweeper here could remove that repo's live stages.

## Test plan

- [x] actionlint: no new findings vs main
- [x] `prettier --check` on changed files
- [x] `tsc --noEmit` over `previews/` (with regenerated SST types): zero errors in sst.config.ts, pre-existing errors unchanged
- [ ] First live run: trigger preview-sweeper via workflow_dispatch and read its log before trusting the schedule

## Changelog

No user-visible change; CI only.

## Notes for reviewers

- Pre-tag orphaned distributions are invisible to the sweeper and need one-off manual cleanup (tracked separately).
- This repo is public: worth checking one `sst remove --print-logs` run's output for sensitive material before relying on it broadly.

## LLM authorship

Written by Claude Code with multi-model review (Codex + Claude passes); human submitter reviewed the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJN1NkhncJtP63bgEXdAgn


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Serialise preview deploy/destroy via concurrency group

- Retry `sst remove` on failure, log output

- Clean up S3 preview prefixes on PR close

- Add weekly sweeper for stale preview stages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  deploy["deploy-preview"] -- "shared concurrency" --> destroy["destroy-preview"]
  destroy -- "retry sst remove" --> remove["cleanup stages"]
  destroy -- "delete prefixes" --> s3["S3 preview prefixes"]
  sweeper["preview-sweeper (weekly)"] -- "match open PRs" --> stale["remove stale stages"]
  tags["repo tag on resources"] --> sweeper
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sst.config.ts</strong><dd><code>Tag preview resources with repo identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

previews/sst.config.ts

<ul><li>Add <code>defaultTags</code> with <code>repo: web-client</code><br> <li> Prevents sweeper from removing sibling web-sdk stages</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/708/files#diff-daaf5ffe465be5314b6a67701b39dafdacfc7fd167a3442734b27e2cd596d68d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deploy-preview.yml</strong><dd><code>Serialise deploy via concurrency group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-preview.yml

<ul><li>Add shared concurrency group keyed on branch<br> <li> <code>cancel-in-progress: false</code> to serialise with destroy</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/708/files#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>destroy-preview.yml</strong><dd><code>Harden destroy with retries and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/destroy-preview.yml

<ul><li>Add matching concurrency group<br> <li> Bind stage via <code>env:</code> and retry <code>sst remove</code> with logging<br> <li> Delete S3 <code>js</code>/<code>inline</code> preview prefixes on close</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/708/files#diff-5bed374909e109c4053da7168d3e96b887f9789fc4bff6b4886e88f1f7872ac8">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preview-sweeper.yml</strong><dd><code>Add weekly stale preview sweeper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/preview-sweeper.yml

<ul><li>New weekly sweeper cross-referencing tagged stages vs open PRs<br> <li> Refuses to run on empty/truncated PR lists<br> <li> Skips protected stages, validates stage names, exits non-zero on <br>failure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/708/files#diff-ebc59f71a104803798ce4ad1a326522b266c3cd8aa77e4c9e85a7111293027c9">+144/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>