### PR TITLE
fix(previews): anchor the whole sst error alternation

### DIFF
--- a/previews/scripts/dev-mobile.sh
+++ b/previews/scripts/dev-mobile.sh
@@ -331,9 +331,11 @@ for _ in $(seq 1 150); do
     break
   fi
   # Match case-sensitively and only at the start of a line: `sst dev` streams
-  # function logs into this file too, and a case-insensitive match would abort a
+  # function logs into this file too, and an unanchored match would abort a
   # healthy deploy on any app log line that merely mentions an error.
-  if grep -qE '^[[:space:]]*(✕|Error:)|does not exist|[Ee]xpired [Tt]oken|ExpiredToken' <<<"$sst_log"; then
+  # Every alternative lives inside the group — `|` binds looser than the `^`
+  # anchor, so hoisting any of them out would leave it matching mid-line.
+  if grep -qE '^[[:space:]]*(✕|Error:|does not exist|[Ee]xpired [Tt]oken|ExpiredToken)' <<<"$sst_log"; then
     echo "❌ sst dev server failed to start. Logs:" >&2
     cat "$SST_SERVER_LOG" >&2
     exit 1


### PR DESCRIPTION
### **User description**
## Summary

`previews/scripts/dev-mobile.sh` aborts a healthy `sst dev` startup when the preview app logs a line containing "does not exist".

The readiness loop scans the sst server log for failures:

```
^[[:space:]]*(✕|Error:)|does not exist|[Ee]xpired [Tt]oken|ExpiredToken
```

`|` binds looser than `^` in ERE, so `^[[:space:]]*` applies only to `(✕|Error:)`. The other three alternatives match **anywhere on a line**. Since `sst dev` streams function logs into the same file this loop is scanning, an ordinary application log line is enough to kill the deploy — which is exactly the false-abort the comment directly above it says it prevents.

Fixed by moving every alternative inside the anchored group, with a comment noting why hoisting one back out would silently reintroduce the bug.

## Verification

Ran both patterns against the same lines:

| line | before | after |
|---|---|---|
| `INFO lookup failed: user does not exist` | **aborts** | ok |
| `log: partner record does not exist, creating` | **aborts** | ok |
| `GET /api/token 200 - token expired token refresh ok` | **aborts** | ok |
| `✕  Failed` | catches | catches |
| `   ✕  Failed to deploy` | catches | catches |
| `Error: Could not find an sst dev session` | catches | catches |
| `ExpiredToken: The security token included is expired` | catches | catches |

Every genuine failure is still caught; all three false positives are gone. `bash -n` clean.

The residual risk runs the other way and is much milder: an sst error that only ever appears mid-line no longer fails fast, and instead waits out the existing 300s timeout — which still dumps the log. Trading "abort a healthy deploy" for "wait for the timeout" is the right direction.

## Scope

Introduced in #651. Touches only `previews/` (private workspace, not published) — no runtime or shipped-code change, no new dependencies.


___

### **PR Type**
Bug fix


___

### **Description**
- Anchor all sst error alternatives inside group

- Prevents false aborts from app log lines

- Update comments explaining ERE precedence pitfall


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sst dev log line"] --> B["readiness loop grep"]
  B -- "before: unanchored alternatives" --> C["false abort on app logs"]
  B -- "after: fully anchored group" --> D["only real sst errors abort"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev-mobile.sh</strong><dd><code>Fix unanchored sst failure regex in readiness loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

previews/scripts/dev-mobile.sh

<ul><li>Moved <code>does not exist</code>, <code>[Ee]xpired [Tt]oken</code> and <code>ExpiredToken</code> inside the <br>anchored <code>^[[:space:]]*(...)</code> group in the readiness-loop failure regex.<br> <li> Fixes ERE precedence bug where <code>|</code> bound looser than <code>^</code>, letting those <br>alternatives match mid-line and abort a healthy <code>sst dev</code> startup.<br> <li> Updated inline comments to explain the anchoring requirement and warn <br>against hoisting alternatives out.</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/web-client/pull/724/files#diff-aca3d438ecd426c454eb639f7d9e551b6170bb228264785633bf26d99a980c93">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>